### PR TITLE
ARCS reduce: support nxs without monitor data

### DIFF
--- a/instruments/ARCS/ARCS/applications/nxs.py
+++ b/instruments/ARCS/ARCS/applications/nxs.py
@@ -34,8 +34,8 @@ def reduce(nxsfile, qaxis, outfile, use_ei_guess=False, ei_guess=None, eaxis=Non
         tof2E = o == 'entry'
 
     if tof2E:
-        ws, mons = Load(nxsfile, LoadMonitors=True)
         if not use_ei_guess:
+            ws, mons = Load(nxsfile, LoadMonitors=True)
             Eguess=ws.getRun()['EnergyRequest'].getStatistics().mean
             try:
                 Efixed,_p,_i,T0=GetEi(InputWorkspace=mons,Monitor1Spec=1,Monitor2Spec=2,EnergyEstimate=Eguess,FixEi=False)
@@ -44,7 +44,8 @@ def reduce(nxsfile, qaxis, outfile, use_ei_guess=False, ei_guess=None, eaxis=Non
                 warnings.warn("Failed to determine Ei from monitors. Use EnergyRequest log %s" % Eguess)
                 Efixed,T0 = Eguess, 0
         else:
-            Efixed, T0 = ei_guess, 0
+            ws = Load(nxsfile)
+            Efixed, T0 = ei_guess, t0_guess or 0.
 
         DgsReduction(
             SampleInputWorkspace=ws,

--- a/instruments/ARCS/ARCS/cli.py
+++ b/instruments/ARCS/ARCS/cli.py
@@ -124,7 +124,7 @@ def populate_metadata(ctx, type, beam_outdir, nxs):
 @nxs.command()
 @click.argument("nxs")
 @click.option('--out', default="iqe.nxs", help="output path. Eg. iqe.nxs")
-@click.option('--use_ei_guess', default=False)
+@click.option('--use_ei_guess', default=False, is_flag=True)
 @click.option('--ei_guess', help='guess for Ei', default=0.)
 @click.option('--t0_guess', help='guess for t0, or emission time', default=0.)
 @click.option('--qaxis', help='Qmin Qmax dQ', default=(0.,13.,0.1))


### PR DESCRIPTION
Fix #250 

After this fix, for data without monitor data, we can set use_ei_guess and ei_guess, t0_guess to have the reduction working