### PR TITLE
Change convention for pyramid: tip at origin

### DIFF
--- a/packages/mccomponents/tests/mccomponents/sample/shape-positioning/pyramid/sampleassembly.xml
+++ b/packages/mccomponents/tests/mccomponents/sample/shape-positioning/pyramid/sampleassembly.xml
@@ -6,7 +6,7 @@
   
   <PowderSample name="X" type="sample">
     <Shape>
-      <translation vector="0.*m,-3*cm,0.*m">
+      <translation vector="0.*m,3*cm,0.*m">
 	<pyramid thickness="1*cm" width="2*cm" height="6*cm" />
       </translation>
     </Shape>

--- a/packages/mccomposite/lib/geometry/primitives/Pyramid.h
+++ b/packages/mccomposite/lib/geometry/primitives/Pyramid.h
@@ -13,7 +13,7 @@ namespace mccomposite{ namespace geometry {
     
     //! pyramid: a Shape
     /// a pyramid. its axis is along z direction
-    /// its base is on the xy plane at z=0
+    /// its tip is at the origin. its base is at negative z
     /// edgeX and edgeY are its dimensions at x and y directions
     struct Pyramid : public AbstractShape {
       

--- a/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
+++ b/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
@@ -350,21 +350,21 @@ mccomposite::geometry::ArrowIntersector::visit
 
   // base
   if (vz!=0) {
-    intersectRectangle(x,y,z, vx,vy,vz, X, Y, ts);
+    intersectRectangle(x,y,z+H, vx,vy,vz, X, Y, ts);
   }
 
   // 4 triangles as sides
   intersectTriangle(start, direction,
-		    Position(0, 0, H), Position(X/2, Y/2, 0), Position(X/2, -Y/2, 0),
+		    Position(0, 0, 0), Position(X/2, Y/2, -H), Position(X/2, -Y/2, -H),
 		    ts);
   intersectTriangle(start, direction,
-		    Position(0, 0, H), Position(X/2, -Y/2, 0), Position(-X/2, -Y/2, 0),
+		    Position(0, 0, 0), Position(X/2, -Y/2, -H), Position(-X/2, -Y/2, -H),
 		    ts);
   intersectTriangle(start, direction,
-		    Position(0, 0, H), Position(-X/2, -Y/2, 0), Position(-X/2, Y/2, 0),
+		    Position(0, 0, 0), Position(-X/2, -Y/2, -H), Position(-X/2, Y/2, -H),
 		    ts);
   intersectTriangle(start, direction,
-		    Position(0, 0, H), Position(-X/2, Y/2, 0), Position(X/2, Y/2, 0),
+		    Position(0, 0, 0), Position(-X/2, Y/2, -H), Position(X/2, Y/2, -H),
 		    ts);
 
 #ifdef DEBUG

--- a/packages/mccomposite/lib/geometry/visitors/Locator.cc
+++ b/packages/mccomposite/lib/geometry/visitors/Locator.cc
@@ -100,16 +100,16 @@ mccomposite::geometry::Locator::visit
   using std::abs;
 
   // z too large or negative, outside
-  if ( z-height > rtol || z<-rtol) { location = outside; return; }
+  if ( z > rtol || z<-height-rtol) { location = outside; return; }
   
   const double & x = point.x;
   const double & y = point.y;
-  double ratio = (height - z)/height;
+  double ratio = -z/height;
   double X1 = ratio*X, Y1 = ratio*Y;
   // x, y too large, outside
   if ( std::abs(x) > X1/2 + rtol || std::abs(y) > Y1/2 + rtol) { location = outside; return; }
-  // 
-  if ( z < height - rtol && z > rtol ) {
+  // z inside
+  if ( z < - rtol && z > -height+rtol ) {
     // z inside, x, y inside, so inside
     if ( std::abs(x) < X1/2 - rtol && std::abs(y) < Y1/2 - rtol) { location = inside; return; }
   } 

--- a/packages/mccomposite/tests/libmccomposite/geometry/testArrowIntersector.cc
+++ b/packages/mccomposite/tests/libmccomposite/geometry/testArrowIntersector.cc
@@ -130,7 +130,7 @@ void test4()
 void test4a()
 {
   Pyramid pyramid(2,3,5);
-  Arrow arrow( Position (0,0,-5), Direction(0,0,1) );
+  Arrow arrow( Position (0,0,-5-5), Direction(0,0,1) );
   // vertical
   ArrowIntersector::distances_t distances = intersect(arrow, pyramid);
   assert (distances.size() == 2);
@@ -138,42 +138,42 @@ void test4a()
   assert (distances[1] == 10 );
 
   // horizontal along x, half height, through axis
-  arrow = Arrow(Position(0,0,2.5), Direction(1,0,0) );
+  arrow = Arrow(Position(0,0,2.5-5), Direction(1,0,0) );
   distances = intersect(arrow, pyramid);
   assert (distances.size() == 2);
   assert (distances[0] == -0.5 );
   assert (distances[1] == 0.5 );
 
   // horizontal along y, half height, through axis
-  arrow = Arrow(Position(0,0,2.5), Direction(0,1,0) );
+  arrow = Arrow(Position(0,0,2.5-5), Direction(0,1,0) );
   distances = intersect(arrow, pyramid);
   assert (distances.size() == 2);
   assert (isclose(distances[0], -0.75 ));
   assert (isclose(distances[1], 0.75 ));
 
   // horizontal along y, half height, not through axis
-  arrow = Arrow(Position(0.5,0,2.5), Direction(0,1,0) );
+  arrow = Arrow(Position(0.5,0,2.5-5), Direction(0,1,0) );
   distances = intersect(arrow, pyramid);
   assert (distances.size() == 2);
   assert (isclose(distances[0], -0.75 ));
   assert (isclose(distances[1], 0.75 ));
 
   // horizontal along xy diagonal, half height, through axis
-  arrow = Arrow(Position(0,0,2.5), Direction(1,1.5,0) );
+  arrow = Arrow(Position(0,0,2.5-5), Direction(1,1.5,0) );
   distances = intersect(arrow, pyramid);
   assert (distances.size() == 2);
   assert (isclose(distances[0], -.5 ));
   assert (isclose(distances[1], .5 ));
   
   // horizontal along xy diagonal, base, through axis
-  arrow = Arrow(Position(0,0,0), Direction(1,1.5,0) );
+  arrow = Arrow(Position(0,0,0-5), Direction(1,1.5,0) );
   distances = intersect(arrow, pyramid);
   assert (distances.size() == 2);
   assert (isclose(distances[0], -1 ));
   assert (isclose(distances[1], 1 ));
 
   // vertical, offset from axis with dx=.5
-  arrow = Arrow(Position(0.5,0,0), Direction(0,0,1) );
+  arrow = Arrow(Position(0.5,0,0-5), Direction(0,0,1) );
   distances = intersect(arrow, pyramid);
   // std::cout << distances << std::endl;
   assert (distances.size() == 2);

--- a/packages/mccomposite/tests/libmccomposite/geometry/testLocator.cc
+++ b/packages/mccomposite/tests/libmccomposite/geometry/testLocator.cc
@@ -69,63 +69,63 @@ void test1c()
 {
   Pyramid pyramid(2,3, 5);
   // center of base
-  assert (locate( Position(0,0,0), pyramid ) == Locator::onborder);
+  assert (locate( Position(0,0,-5), pyramid ) == Locator::onborder);
   // inside, along axis
-  assert (locate( Position(0,0,1), pyramid ) == Locator::inside);
-  assert (locate( Position(0,0,2), pyramid ) == Locator::inside);
-  assert (locate( Position(0,0,4.99), pyramid ) == Locator::inside);
+  assert (locate( Position(0,0,1-5), pyramid ) == Locator::inside);
+  assert (locate( Position(0,0,2-5), pyramid ) == Locator::inside);
+  assert (locate( Position(0,0,4.99-5), pyramid ) == Locator::inside);
   // outside, along axis
-  assert (locate( Position(0,0,5.01), pyramid ) == Locator::outside);
+  assert (locate( Position(0,0,5.01-5), pyramid ) == Locator::outside);
   // base, corner
-  assert (locate( Position(1,1.5,0), pyramid ) == Locator::onborder);
+  assert (locate( Position(1,1.5,0-5), pyramid ) == Locator::onborder);
   // inside, near base, near corner
-  assert (locate( Position(1-0.02,1.5-0.02,0+0.01), pyramid ) == Locator::inside);
+  assert (locate( Position(1-0.02,1.5-0.02,0+0.01-5), pyramid ) == Locator::inside);
   // inside, near base, near edge
-  assert (locate( Position(1-0.02,0,0+0.01), pyramid ) == Locator::inside);
+  assert (locate( Position(1-0.02,0,0+0.01-5), pyramid ) == Locator::inside);
   // inside, near base, near another corner
-  assert (locate( Position(1-0.02,-1.5+0.02,0+0.01), pyramid ) == Locator::inside);
+  assert (locate( Position(1-0.02,-1.5+0.02,0+0.01-5), pyramid ) == Locator::inside);
   // inside, near base, near another corner
-  assert (locate( Position(-1+0.02,-1.5+0.02,0+0.01), pyramid ) == Locator::inside);
+  assert (locate( Position(-1+0.02,-1.5+0.02,0+0.01-5), pyramid ) == Locator::inside);
   // outside, near base, near corner
-  assert (locate( Position(1+0.02,1.5+0.02,0+0.01), pyramid ) == Locator::outside);
+  assert (locate( Position(1+0.02,1.5+0.02,0+0.01-5), pyramid ) == Locator::outside);
   // outside, near base, near edge
-  assert (locate( Position(1+0.02,0,0+0.01), pyramid ) == Locator::outside);
+  assert (locate( Position(1+0.02,0,0+0.01-5), pyramid ) == Locator::outside);
   // outside, near base, near another corner
-  assert (locate( Position(1+0.02,-1.5+0.02,0+0.01), pyramid ) == Locator::outside);
+  assert (locate( Position(1+0.02,-1.5+0.02,0+0.01-5), pyramid ) == Locator::outside);
   // outside, near base, near another corner
-  assert (locate( Position(-1+0.02,-1.5-0.02,0+0.01), pyramid ) == Locator::outside);
+  assert (locate( Position(-1+0.02,-1.5-0.02,0+0.01-5), pyramid ) == Locator::outside);
   // base, on border, near a corner
-  assert (locate( Position(-1,-1.5,0), pyramid ) == Locator::onborder);
+  assert (locate( Position(-1,-1.5,0-5), pyramid ) == Locator::onborder);
   // outside, near tip
-  assert (locate( Position(.2,.2,5), pyramid ) == Locator::outside);
+  assert (locate( Position(.2,.2,5-5), pyramid ) == Locator::outside);
   // inside, near tip
-  assert (locate( Position(0,0,5-0.01), pyramid ) == Locator::inside);
+  assert (locate( Position(0,0,5-0.01-5), pyramid ) == Locator::inside);
   // border, tip
-  assert (locate( Position(0,0,5), pyramid ) == Locator::onborder);
+  assert (locate( Position(0,0,5-5), pyramid ) == Locator::onborder);
   // inside, half hight, near corner
-  assert (locate( Position(.5-0.02,.75-0.02,2.5), pyramid ) == Locator::inside);
+  assert (locate( Position(.5-0.02,.75-0.02,2.5-5), pyramid ) == Locator::inside);
   // inside, half hight, near edge
-  assert (locate( Position(.5-0.02,0,2.5), pyramid ) == Locator::inside);
+  assert (locate( Position(.5-0.02,0,2.5-5), pyramid ) == Locator::inside);
   // inside, half hight, near another corner
-  assert (locate( Position(.5-0.02,-.75+0.02,2.5), pyramid ) == Locator::inside);
+  assert (locate( Position(.5-0.02,-.75+0.02,2.5-5), pyramid ) == Locator::inside);
   // inside, half hight, near another corner
-  assert (locate( Position(-.5+0.02,-.75+0.02,2.5), pyramid ) == Locator::inside);
+  assert (locate( Position(-.5+0.02,-.75+0.02,2.5-5), pyramid ) == Locator::inside);
   // outside, half hight, near corner
-  assert (locate( Position(.5+0.02,.75+0.02,2.5), pyramid ) == Locator::outside);
+  assert (locate( Position(.5+0.02,.75+0.02,2.5-5), pyramid ) == Locator::outside);
   // outside, half hight, near edge
-  assert (locate( Position(.5+0.02,0,2.5), pyramid ) == Locator::outside);
+  assert (locate( Position(.5+0.02,0,2.5-5), pyramid ) == Locator::outside);
   // outside, half hight, near another corner
-  assert (locate( Position(.5+0.02,-.75+0.02,2.5), pyramid ) == Locator::outside);
+  assert (locate( Position(.5+0.02,-.75+0.02,2.5-5), pyramid ) == Locator::outside);
   // outside, half hight, near another corner
-  assert (locate( Position(-.5+0.02,-.75-0.02,2.5), pyramid ) == Locator::outside);
+  assert (locate( Position(-.5+0.02,-.75-0.02,2.5-5), pyramid ) == Locator::outside);
   // onborder, half hight, near corner
-  assert (locate( Position(.5,.75,2.5), pyramid ) == Locator::onborder);
+  assert (locate( Position(.5,.75,2.5-5), pyramid ) == Locator::onborder);
   // onborder, half hight, near edge
-  assert (locate( Position(.5,0,2.5), pyramid ) == Locator::onborder);
+  assert (locate( Position(.5,0,2.5-5), pyramid ) == Locator::onborder);
   // onborder, half hight, near another corner
-  assert (locate( Position(.5,-.75,2.5), pyramid ) == Locator::onborder);
+  assert (locate( Position(.5,-.75,2.5-5), pyramid ) == Locator::onborder);
   // onborder, half hight, near another corner
-  assert (locate( Position(-.5,-.75,2.5), pyramid ) == Locator::onborder);
+  assert (locate( Position(-.5,-.75,2.5-5), pyramid ) == Locator::onborder);
 }
 
 void test2()


### PR DESCRIPTION
Refs #272 

Was using the convention that the base center is at origin. In this PR we move the tip of the pyramid to the origin. The base is at negative z. This way it is easier to rotate it to the desired orientation, and then move it to the desired location.