### PR TITLE
replace `exit` in mcstas monitor components with `throw exception`

### DIFF
--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/DivLambda_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/DivLambda_monitor.comp
@@ -90,7 +90,7 @@ INITIALIZE
             printf("DivLambda_monitor: %s: Null detection area !\n"
                    "ERROR              (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("DivLambda_monitor: bad detector dimension");
     }
 
     for (i=0; i<nlam; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/DivPos_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/DivPos_monitor.comp
@@ -87,7 +87,7 @@ INITIALIZE
             printf("DivPos_monitor: %s: Null detection area !\n"
                    "ERROR           (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("DivPos_monitor: bad detector dimension");
     }
 
     for (i=0; i<npos; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/Divergence_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/Divergence_monitor.comp
@@ -87,7 +87,7 @@ INITIALIZE
             printf("Divergence_monitor: %s: Null detection area !\n"
                    "ERROR               (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("Divergence_monitor: bad detector dimension");
     }
 
     for (i=0; i<nh; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/EPSD_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/EPSD_monitor.comp
@@ -87,7 +87,7 @@ INITIALIZE
             printf("EPSD_monitor: %s: Null detection area !\n"
                    "ERROR         (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("EPSD_monitor: bad detector dimension");
     }
 
     for (i=0; i<nx; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/E_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/E_monitor.comp
@@ -65,7 +65,7 @@ INITIALIZE
 
     if (nchan <= 0) {
       printf("E_monitor: number of channel must be positive.\n" );
-      exit(0);
+      throw Exception("E_monitor: number of channel must be positive");
     }
     E_N = new double[ nchan ];
     E_p = new double[ nchan ];

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/Hdiv_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/Hdiv_monitor.comp
@@ -73,7 +73,7 @@ INITIALIZE
             printf("Hdiv_monitor: %s: Null detection area !\n"
                    "ERROR         (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("Hdiv_monitor: bad detector dimension");
     }
 
     for (i=0; i<nh; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/L_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/L_monitor.comp
@@ -47,7 +47,7 @@
 *******************************************************************************/
 
 DEFINE COMPONENT L_monitor
-DEFINITION PARAMETERS (nchan=20, string filename)
+DEFINITION PARAMETERS (int nchan=20, string filename)
 SETTING PARAMETERS (xmin=0, xmax=0, ymin=0, ymax=0, xwidth=0, yheight=0, Lmin, Lmax)
 OUTPUT PARAMETERS (L_N, L_p, L_p2)
 STATE PARAMETERS (x,y,z,vx,vy,vz,t,s1,s2,p)
@@ -72,7 +72,7 @@ INITIALIZE
             printf("L_monitor: %s: Null detection area !\n"
                    "ERROR      (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("L_monitor: bad detector dimension");
     }
 
     for (i=0; i<nchan; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/Monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/Monitor.comp
@@ -64,7 +64,7 @@ INITIALIZE
             printf("Monitor: %s: Null detection area !\n"
                    "ERROR    (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("Monitor: bad detector dimension");
     }
   %}
 TRACE

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/PSD_TEW_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/PSD_TEW_monitor.comp
@@ -86,25 +86,25 @@ INITIALIZE
 
     if(!(strcmp(type,"time")==0) && !(strcmp(type,"energy")==0) && !(strcmp(type,"wavelength")==0)) {
        printf("PSD_TEW: error in type keyword\n stop\n");
-       exit(0);
+       throw Exception("PSD_TEW: error in type keyword");
     }
     if(!(strcmp(format,"table")==0) && !(strcmp(format,"McStas")==0)) {
        printf("PSD_TEW: error in format keyword\n");
        printf("PSD_TEW: data are not recorded!");
-       exit(0);
+       throw Exception("PSD_TEW: error in format keyword");
     }
     if ((xwidth<=0) || (yheight<0)) {
        printf("PSD TOFEL: %s: Null detection area !\n" 
               "ERROR        (xwidth,yheight). Exiting",
               NAME_CURRENT_COMP);
-       exit(0);
+       throw Exception("PSD_TEW: Null detection area");
     }
 
     if ((bmin >= bmax) && (bmax > 0)) {
        printf("PSD tew: %s:  bmin larger bmax !\n" 
               "ERROR        (bmin,bmax). Exiting",
               NAME_CURRENT_COMP);
-        exit(0);
+       throw Exception("PSD_tew: bad bmin, bmax");
     }
 
 

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/PSD_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/PSD_monitor.comp
@@ -90,7 +90,7 @@ INITIALIZE
             printf("PSD_monitor: %s: Null detection area !\n"
                    "ERROR        (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("PSD_monitor: bad detector dimension");
     }
 
     for (i=0; i<nx; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/PSDlin_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/PSDlin_monitor.comp
@@ -70,7 +70,7 @@ INITIALIZE
             printf("PSDlin_monitor: %s: Null detection area !\n"
                    "ERROR           (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("PSDlin_monitor: bad detector dimension");
     }
 
     for (i=0; i<nx; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOF2E_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOF2E_monitor.comp
@@ -53,7 +53,7 @@
 *******************************************************************************/
 
 DEFINE COMPONENT TOF2E_monitor
-DEFINITION PARAMETERS (nchan=20, string filename)
+DEFINITION PARAMETERS (int nchan=20, string filename)
 SETTING PARAMETERS (xmin=0, xmax=0, ymin=0, ymax=0, xwidth=0, yheight=0, Emin, Emax, T_zero, L_flight)
 OUTPUT PARAMETERS (E_N, E_p, E_p2, S_p, S_pE, S_pE2)
 STATE PARAMETERS (x,y,z,vx,vy,vz,t,s1,s2,p)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOFLambda_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOFLambda_monitor.comp
@@ -87,7 +87,7 @@ INITIALIZE
             printf("TOFLambda_monitor: %s: Null detection area !\n"
                    "ERROR              (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("TOFLambda_monitor: bad detector dimension");
     }
 
     tt_0 = t_0*1e-6;

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOF_monitor.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOF_monitor.comp
@@ -72,7 +72,7 @@ INITIALIZE
             printf("TOF_monitor: %s: Null detection area !\n"
                    "ERROR        (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("TOF_monitor: bad detector dimension");
     }
 
     for (i=0; i<nchan; i++)

--- a/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOFlog_mon.comp
+++ b/packages/legacycomponents/mcstas2/share/McStas-Components/monitors/TOFlog_mon.comp
@@ -78,7 +78,7 @@ INITIALIZE
             printf("TOFlog_mon: %s: Null detection area !\n"
                    "ERROR       (xwidth,yheight,xmin,xmax,ymin,ymax). Exiting",
            NAME_CURRENT_COMP);
-      exit(0);
+      throw Exception("TOFlog_mon: Null detection area");
     }
 
     nchan=(int)ceil(ndec*log(thigh/tlow)/log(10.0));

--- a/packages/mcvine/tests/mcvine/components/monitors_TestCase.py
+++ b/packages/mcvine/tests/mcvine/components/monitors_TestCase.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Jiao Lin <jiao.lin@gmail.com>
+#
+
+
+import os
+os.environ['MCVINE_MPI_BINDING'] = 'NONE'
+
+
+import unittest
+
+
+class TestCase(unittest.TestCase):
+
+
+    def test1(self):
+        'mcvine: simulate'
+        # this is the example 1 in the mcvine package documentation
+        import mcvine, mcvine.components
+        i = mcvine.instrument()
+        # add source
+        i.append(mcvine.components.sources.Source_simple('source'), position=(0,0,0))
+        # add monitor
+        i.append(mcvine.components.monitors.L_monitor('monitor', filename='IL.dat'), position=(0,0,1))
+        #
+        try:
+            neutrons = i.simulate(5,outputdir="out-mcvine", overwrite_datafiles=True, iteration_no=0)
+        except Exception as e:
+            assert "bad detector dimension" in str(e)
+            return
+        raise RuntimeError("Expecting an exception")
+        return
+
+    def test1a(self):
+        import mcvine, mcvine.components
+        i = mcvine.instrument()
+        # add source
+        i.append(mcvine.components.sources.Source_simple('source'), position=(0,0,0))
+        # add monitor
+        m = mcvine.components.monitors.L_monitor(
+            'monitor', Lmin=0, Lmax=15, nchan=150, xwidth=.01, yheight=.01, filename='IL.data')
+        i.append(m, position=(0,0,1))
+        neutrons = i.simulate(5,outputdir="out-mcvine", overwrite_datafiles=True, iteration_no=0)
+        return
+
+    
+    def test2(self):
+        'mcvine: simulate'
+        # this is the example 1 in the mcvine package documentation
+        import mcvine, mcvine.components
+        i = mcvine.instrument()
+        # add source
+        i.append(mcvine.components.sources.Source_simple('source'), position=(0,0,0))
+        # add monitor
+        i.append(mcvine.components.monitors.PSD_monitor('monitor'), position=(0,0,1))
+        #
+        try:
+            neutrons = i.simulate(5,outputdir="out-mcvine", overwrite_datafiles=True, iteration_no=0)
+        except Exception as e:
+            assert "bad detector dimension" in str(e)
+            return
+        raise RuntimeError("Expecting an exception")
+        return
+
+
+    pass  # end of TestCase
+
+
+
+if __name__ == "__main__": unittest.main(); print 1
+    
+# End of file 


### PR DESCRIPTION
fix #334 