### PR TITLE
fix pyramid and cone ray-tracing error

### DIFF
--- a/packages/mccomponents/tests/mccomponents/sample/shape-positioning/cone_TestCase.py
+++ b/packages/mccomponents/tests/mccomponents/sample/shape-positioning/cone_TestCase.py
@@ -30,7 +30,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(bpb.locate(bpb.position(0., 0.0, 0.), shape), 'inside')
 
         # neutrons
-        N = 1000
+        N = 100000
         neutrons = mcni.neutron_buffer(N)
         neutrons = source.process(neutrons)
         # find neutrons out of target
@@ -42,7 +42,9 @@ class TestCase(unittest.TestCase):
         # print neutrons
         arr = neutrons.to_npyarr()
         x,y,z = arr[:, :3].T
-        assert (z[missing] < -.9).all()
+        z1 = z[missing]
+        print z1[z1>=-0.9]
+        assert (z1>=-0.0).sum() < 1e-4*N
         hit = arr[np.logical_not(missing), :3]
         x,y,z = hit.T
         assert (

--- a/packages/mccomponents/tests/mccomponents/sample/shape-positioning/pyramid_TestCase.py
+++ b/packages/mccomponents/tests/mccomponents/sample/shape-positioning/pyramid_TestCase.py
@@ -28,7 +28,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(bpb.locate(bpb.position(0., 0.0, 0.), shape), 'inside')
 
         # neutrons
-        N = 1000
+        N = 100000
         neutrons = mcni.neutron_buffer(N)
         neutrons = source.process(neutrons)
         # find neutrons out of target
@@ -56,7 +56,11 @@ class TestCase(unittest.TestCase):
     pass  # end of scattererxml_TestCase
 
 
-def main(): unittest.main()
+def main():
+    import journal
+    debug = journal.debug("mccomposite.geometry.ArrowIntersector")
+    debug.activate()
+    unittest.main()
 
 if __name__ == "__main__": main()
     

--- a/packages/mccomposite/lib/geometry/tolerance.h
+++ b/packages/mccomposite/lib/geometry/tolerance.h
@@ -16,7 +16,7 @@
 
 namespace mccomposite {
   namespace geometry {
-    const double tolerance = 1.e-7;
+    const double tolerance = 1.e-7; // tolerance for distance in meters
   }
 }
 

--- a/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
+++ b/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
@@ -18,6 +18,22 @@ namespace ArrowIntersector_impl{
   
 }
 
+namespace mccomposite{ namespace geometry{
+    /*
+    inline bool eq_double( double a, double b ) 
+    {
+      double max = std::max(std::abs(a), std::abs(b));
+      return max < tolerance || std::abs((a-b)/max) < tolerance ;
+    }
+    */
+    
+    inline bool eq_withinepsilon(double x, double y)
+    {
+      return std::abs(x-y) < tolerance/5.;
+    }
+  }
+}
+
 
 // meta-methods
 mccomposite::geometry::ArrowIntersector::ArrowIntersector
@@ -198,12 +214,6 @@ namespace {
       ts.push_back(t);
   }
 
-  // 
-  const double epsilon = 1.e-7;
-  inline bool eq_withinepsilon(double x, double y)
-  {
-    return std::abs(x-y) < epsilon;
-  }
 }
 
 // visiting methods
@@ -324,8 +334,10 @@ mccomposite::geometry::ArrowIntersector::visit
   const Pyramid & pyramid = *pyramidptr;
   
   const Position & start = m_arrow.start;
-  const Direction & direction = m_arrow.direction;
+  Direction direction = m_arrow.direction;
   if (isInvaildDirection(direction)) return;
+  double length = direction.length();
+  direction= direction * (1./length); // normalize
   
 #ifdef DEBUG
   debug << journal::at(__HERE__) 
@@ -371,7 +383,7 @@ mccomposite::geometry::ArrowIntersector::visit
 	<< ts << journal::endl
     ;
 #endif
-  
+
   if (!ts.size()) return;
   // remove duplicates
   std::sort(ts.begin(), ts.end());  // have to sort otherwise unique does not work well
@@ -385,7 +397,9 @@ mccomposite::geometry::ArrowIntersector::visit
     debug
       << journal::at(__HERE__)
       << "number of intersections between a line and a pyramid should be 0 or 2, "
-      << "we got " << ts.size() << ". " << journal::newline
+      << "we got " << N << ". " << journal::newline;
+    for (std::vector<double>::iterator it=ts.begin(); it!=new_end; it++) oss << *it << ", ";
+    oss << std::endl
       << "pyramid: " << pyramid << ", "
       << "arrow: " << m_arrow
       << journal::endl;
@@ -406,11 +420,11 @@ mccomposite::geometry::ArrowIntersector::visit
   }
   
   if (ts[0] < ts[1]) {
-    m_distances.push_back(ts[0]);
-    m_distances.push_back(ts[1]);
+    m_distances.push_back(ts[0]/length);
+    m_distances.push_back(ts[1]/length);
   } else {
-    m_distances.push_back(ts[1]);
-    m_distances.push_back(ts[0]);
+    m_distances.push_back(ts[1]/length);
+    m_distances.push_back(ts[0]/length);
   }
   
 #ifdef DEBUG
@@ -435,8 +449,10 @@ mccomposite::geometry::ArrowIntersector::visit
   const Cone & cone = *coneptr;
   
   const Position & start = m_arrow.start;
-  const Direction & direction = m_arrow.direction;
+  Direction direction = m_arrow.direction;
   if (isInvaildDirection(direction)) return;
+  double length = direction.length();
+  direction = direction * (1./length); // normalize
   
 #ifdef DEBUG
   debug << journal::at(__HERE__) 
@@ -509,7 +525,7 @@ mccomposite::geometry::ArrowIntersector::visit
   for (int i=0; i<N; i++) {
     // compute z
     double z1 = z+t1[i]*vz;
-    if (z1<epsilon/2 && z1>=-H-epsilon/2) ts.push_back(t1[i]);
+    if (z1<tolerance/2 && z1>=-H-tolerance/2) ts.push_back(t1[i]);
   }
   
   // base
@@ -558,11 +574,11 @@ mccomposite::geometry::ArrowIntersector::visit
   }
   
   if (ts[0] < ts[1]) {
-    m_distances.push_back(ts[0]);
-    m_distances.push_back(ts[1]);
+    m_distances.push_back(ts[0]/length);
+    m_distances.push_back(ts[1]/length);
   } else {
-    m_distances.push_back(ts[1]);
-    m_distances.push_back(ts[0]);
+    m_distances.push_back(ts[1]/length);
+    m_distances.push_back(ts[0]/length);
   }
   
 #ifdef DEBUG
@@ -767,15 +783,6 @@ namespace ArrowIntersector_impl{
 		    isnotonborder); 
   }
 
-}
-
-namespace mccomposite{ namespace geometry{
-    inline bool eq_double( double a, double b ) 
-    {
-      double max = std::max(std::abs(a), std::abs(b));
-      return max < tolerance || std::abs((a-b)/max) < tolerance ;
-    }
-  }
 }
 
 void 


### PR DESCRIPTION
When neutron is very close to the tip of either a pyramid or a cone, mcvine may throw an exception complaining `cannot find intersections in the forward direction`. This is due to rounding error.

fixes #350 