### PR TITLE
Bug for cone intersection

### DIFF
--- a/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
+++ b/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <sstream>
+#include <iomanip>
 
 #include "mccomposite/geometry/visitors/ArrowIntersector.h"
 #include "mccomposite/geometry/visitors/Locator.h"
@@ -525,7 +526,7 @@ mccomposite::geometry::ArrowIntersector::visit
   for (int i=0; i<N; i++) {
     // compute z
     double z1 = z+t1[i]*vz;
-    if (z1<tolerance/2 && z1>=-H-tolerance/2) ts.push_back(t1[i]);
+    if (z1<tolerance/10 && z1>=-H-tolerance/10) ts.push_back(t1[i]);
   }
   
   // base
@@ -564,6 +565,7 @@ mccomposite::geometry::ArrowIntersector::visit
     std::ostringstream oss;
     oss << "number of intersections between a line and a cone should be 0 or 2, "
 	<< "we got " << N << ": " ;
+    oss << std::setprecision(20);
     for (std::vector<double>::iterator it=ts.begin(); it!=new_end; it++) oss << *it << ", ";
     oss << std::endl
 	<< cone << ", "

--- a/packages/mccomposite/tests/libmccomposite/CMakeLists.txt
+++ b/packages/mccomposite/tests/libmccomposite/CMakeLists.txt
@@ -12,6 +12,7 @@ set ( SRC_FILES
   geometry/testOverlap.cc
   geometry/test_intersect.cc
   geometry/test_intersectTriangle.cc
+  geometry/test_intersect_cone.cc
   mccomposite/testAbstractNeutronScatterer.cc
   mccomposite/testCompositeNeutronScatterer.cc
   mccomposite/testGeometer.cc

--- a/packages/mccomposite/tests/libmccomposite/geometry/test_intersect_cone.cc
+++ b/packages/mccomposite/tests/libmccomposite/geometry/test_intersect_cone.cc
@@ -1,0 +1,70 @@
+// -*- C++ -*-
+//
+//
+
+#include <cstdlib>
+#include <cassert>
+#include <iostream>
+#include <cmath>
+#include "mcni/test/assert.h"
+#include "mccomposite/geometry/shapes.h"
+#include "mccomposite/geometry/intersect.h"
+
+#include "journal/debug.h"
+
+using namespace std;
+using namespace mccomposite::geometry;
+
+
+namespace {
+  double random( double min, double max )
+  {
+    using namespace std;
+    return rand()*1./RAND_MAX*(max-min) + min;
+  }
+}
+
+// special case where cone intersection has failed
+void test1()
+{
+  Cone cone(0.00914101, 0.523688);
+  Position start(-0.002106752520420636203,-0.014995300371214700941,-0.47812284760090373315);
+  Direction direction(-191.69,-1150.83,2190.32);
+  Arrow arrow(start, direction);
+  ArrowIntersector::distances_t dists = intersect( arrow, cone );
+}
+
+
+// run a Monte Carlo
+void test2()
+{
+  Cone cone(0.,1.);
+  
+  int N = 20000000;
+  for (int i=0; i<N; i++) {
+    cone.radius = exp(random(-3, 0));
+    cone.height = exp(random(-3, 1));
+    double x = random(-.2,.2), y = random(-.2,.2), z = random(-.2,.2);
+    Position start(x,y,z);
+    double vx = random(-1.,1.), vy = random(-1.,1.), vz = random(-1.,1.);
+    Direction direction(vx,vy,vz);
+    Arrow arrow(start, direction);
+    ArrowIntersector::distances_t dists = intersect( arrow, cone );
+    dists = intersect( arrow, cone );
+  }
+  // std::cout << dists << std::endl;
+}
+
+
+int main()
+{
+#ifdef DEBUG
+//  journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
+//   journal::debug_t("mccomposite.geometry.Locator").activate();
+//   journal::debug_t("mccomposite.geometry.intersect").activate();
+#endif
+  test1();
+  test2();
+}
+
+// End of file 


### PR DESCRIPTION
@Fahima-Islam found this bug when running a simulation with a cone shape. Here is the error msg:

```
RuntimeError: number of intersections between a line and a cone should be 0 or 2, we got 3: 
-0.0641432, -0.0641432, -0.019877, Cone(radius=0.00898646,height=0.514834,), 
arrow: (0.00610951,0.0148147,-0.455768)-->(219.074,541.195,1378.86) 4.426622e-02
```