### PR TITLE
fix travis builds

### DIFF
--- a/builders/travis-conda/meta.yaml.template
+++ b/builders/travis-conda/meta.yaml.template
@@ -31,6 +31,8 @@ requirements:
     - mcvine-resources
 
   run:
+    - {{ compiler('cxx') }}  # [linux]
+    - cmake
     - python
     - pyyaml
     - numpy
@@ -50,7 +52,6 @@ requirements:
     - drchops
     - mcvine-resources
     - phonopy
-    - cmake
 
 build:
   script_env:


### PR DESCRIPTION
travis has been failing: https://travis-ci.org/mcvine/mcvine/builds/498846910

Two tests failed because they are building mcstas-component binding on-the-fly. It looks like we need to include compiler when running mcvine