### PR TITLE
boost python binding of dispersion object: support numpy arrays

### DIFF
--- a/packages/mccomponents/mccomponentsbpmodule/wrap_AbstractDispersion_3D.cc
+++ b/packages/mccomponents/mccomponentsbpmodule/wrap_AbstractDispersion_3D.cc
@@ -1,23 +1,39 @@
 // -*- C++ -*-
 //
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-//
-//                                   Jiao Lin
-//                      California Institute of Technology
-//                         (C) 2007 All Rights Reserved
-//
-// {LicenseText}
-//
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Jiao Lin <jiao.lin@gmail.com>
 //
 
 
 #include <sstream>
 #include <boost/python.hpp>
 #include "mccomponents/kernels/sample/phonon/AbstractDispersion_3D.h"
-
+#include "histogram/NdArray.h"
 
 namespace wrap_mccomponents {
+
+  // helper functions
+  typedef DANSE::Histogram::NdArray<double *, double, unsigned int, size_t, 2> array_2d_t;
+  typedef DANSE::Histogram::NdArray<double *, double, unsigned int, size_t, 3> array_3d_t;
+  // Qarr: NQX3 array
+  // Earr: NQXnbranches array
+  void disp_energies(DANSE::phonon::AbstractDispersion_3D &disp, const array_2d_t &Qarr, array_2d_t &Earr)
+  {
+    typedef mcni::Vector3<double> V3;
+    size_t nbr = disp.nBranches();
+    size_t nQ = Qarr.shape()[0];
+    assert (Qarr.shape()[1]==3);
+    array_2d_t::index_t xind[2], yind[2], zind[2];
+    xind[1]=0; yind[1]=1; zind[1]=2;
+    array_2d_t::index_t Eind[2];
+    for (int iQ=0; iQ<nQ; iQ++) {
+      xind[0]=yind[0]=zind[0]=Eind[0] = iQ;
+      V3 Q(Qarr[xind], Qarr[yind], Qarr[zind]);
+      for (int ibr=0; ibr<nbr; ibr++) {
+	Eind[1] = ibr;
+	Earr[Eind] = disp.energy(ibr, Q);
+      }
+    }
+  }
 
   void wrap_AbstractDispersion_3D()
   {
@@ -30,13 +46,11 @@ namespace wrap_mccomponents {
       .def("nAtoms", &w_t::nAtoms )
       .def("energy", &w_t::energy )
       .def("polarization", &w_t::polarization )
+      .def("energy_arr", disp_energies)
       ;
   }
 
 }
 
-
-// version
-// $Id$
 
 // End of file 

--- a/packages/mccomponents/mccomponentsbpmodule/wrap_AbstractDispersion_3D.cc
+++ b/packages/mccomponents/mccomponentsbpmodule/wrap_AbstractDispersion_3D.cc
@@ -13,7 +13,7 @@ namespace wrap_mccomponents {
 
   // helper functions
   typedef DANSE::Histogram::NdArray<double *, double, unsigned int, size_t, 2> array_2d_t;
-  typedef DANSE::Histogram::NdArray<double *, double, unsigned int, size_t, 3> array_3d_t;
+  typedef DANSE::Histogram::NdArray<double *, double, unsigned int, size_t, 4> array_4d_t;
   // Qarr: NQX3 array
   // Earr: NQXnbranches array
   void disp_energies(DANSE::phonon::AbstractDispersion_3D &disp, const array_2d_t &Qarr, array_2d_t &Earr)
@@ -34,6 +34,36 @@ namespace wrap_mccomponents {
       }
     }
   }
+  // Qarr: NQX3 array
+  // realpolarr, imagpolarr: NQXnbranchesXnatomsX3 array
+  void disp_pols
+  (DANSE::phonon::AbstractDispersion_3D &disp, const array_2d_t &Qarr, array_4d_t &realpolarr, array_4d_t &imagpolarr)
+  {
+    typedef mcni::Vector3<double> V3;
+    size_t nbr = disp.nBranches();
+    size_t natom = disp.nAtoms();
+    size_t nQ = Qarr.shape()[0];
+    assert (Qarr.shape()[1]==3);
+    array_2d_t::index_t xind[2], yind[2], zind[2];
+    xind[1]=0; yind[1]=1; zind[1]=2;
+    array_4d_t::index_t xpolind[4], ypolind[4], zpolind[4];
+    xpolind[3]=0; ypolind[3]=1; zpolind[3]=2;
+    DANSE::phonon::AbstractDispersion_3D::epsilon_t pol;
+    for (int iQ=0; iQ<nQ; iQ++) {
+      xind[0]=yind[0]=zind[0]=xpolind[0] = ypolind[0] = zpolind[0] = iQ;
+      V3 Q(Qarr[xind], Qarr[yind], Qarr[zind]);
+      for (int ibr=0; ibr<nbr; ibr++) {
+	xpolind[1] = ypolind[1] = zpolind[1] = ibr;
+	for (int iatom=0; iatom<natom; iatom++) {
+	  xpolind[2] = ypolind[2] = zpolind[2] = iatom;
+	  pol = disp.polarization(ibr, iatom, Q);
+	  realpolarr[xpolind] = pol[0].real(); imagpolarr[xpolind] = pol[0].imag();
+	  realpolarr[ypolind] = pol[1].real(); imagpolarr[ypolind] = pol[1].imag();
+	  realpolarr[zpolind] = pol[2].real(); imagpolarr[zpolind] = pol[2].imag();
+	}
+      }
+    }
+  }
 
   void wrap_AbstractDispersion_3D()
   {
@@ -47,6 +77,7 @@ namespace wrap_mccomponents {
       .def("energy", &w_t::energy )
       .def("polarization", &w_t::polarization )
       .def("energy_arr", disp_energies)
+      .def("polarization_arr", disp_pols)
       ;
   }
 

--- a/packages/mccomponents/tests/mccomponents/sample/phonon/dispersion_TestCase.py
+++ b/packages/mccomponents/tests/mccomponents/sample/phonon/dispersion_TestCase.py
@@ -14,6 +14,7 @@
 
 
 import unittestX as unittest
+import numpy as np
 import journal
 
 #debug = journal.debug( "TestCase" )
@@ -62,15 +63,26 @@ class TestCase(unittest.TestCase):
         qs = [ (0, 0, ra * i/N) for i in range(N) ]
         from mccomponents.sample.phonon.bindings import default
         binding = default()
-        es = [ disp.energy(0, binding.Q(q)) for q in qs ]
-        print qs, es
+        es = [
+            [ disp.energy(ibr, binding.Q(q)) for ibr in range(3) ]
+            for q in qs
+        ]
 
         q = qx, qy, qz = 1.2, 0.3, 0.22
         Q = binding.Q( q )
         self.assertAlmostEqual(
             disp.energy(0, binding.Q( qx + 2*ra, qy + 8*ra, qz - 6*ra )),
             disp.energy(0, Q ), 3 )
-                                            
+
+        Qarr = np.array(qs)
+        Es = np.zeros((len(qs), disp.nBranches()))
+        disp.energy_arr(binding.ndarray(Qarr), binding.ndarray(Es))
+        self.assert_(np.allclose( np.array(es), Es ))
+
+        Nq = 1000000
+        Qbigarr = np.zeros((Nq, 3))
+        Ebigarr = np.zeros((Nq, disp.nBranches()))
+        disp.energy_arr(binding.ndarray(Qbigarr), binding.ndarray(Ebigarr))
         return
         
         

--- a/packages/mccomponents/tests/mccomponents/sample/phonon/dispersion_TestCase.py
+++ b/packages/mccomponents/tests/mccomponents/sample/phonon/dispersion_TestCase.py
@@ -63,8 +63,13 @@ class TestCase(unittest.TestCase):
         qs = [ (0, 0, ra * i/N) for i in range(N) ]
         from mccomponents.sample.phonon.bindings import default
         binding = default()
-        es = [
+        Es1 = [
             [ disp.energy(ibr, binding.Q(q)) for ibr in range(3) ]
+            for q in qs
+        ]
+        pols1 = [
+            [[disp.polarization(ibr, iatom, binding.Q(q)) for iatom in range(1)]
+             for ibr in range(3)]
             for q in qs
         ]
 
@@ -75,14 +80,23 @@ class TestCase(unittest.TestCase):
             disp.energy(0, Q ), 3 )
 
         Qarr = np.array(qs)
-        Es = np.zeros((len(qs), disp.nBranches()))
-        disp.energy_arr(binding.ndarray(Qarr), binding.ndarray(Es))
-        self.assert_(np.allclose( np.array(es), Es ))
+        Es2 = np.zeros((len(qs), disp.nBranches()))
+        disp.energy_arr(binding.ndarray(Qarr), binding.ndarray(Es2))
+        self.assert_(np.allclose( np.array(Es1), Es2 ))
+
+        real_pols2 = np.zeros( (len(qs), disp.nBranches(), disp.nAtoms(), 3) )
+        imag_pols2 = np.zeros( (len(qs), disp.nBranches(), disp.nAtoms(), 3) )
+        disp.polarization_arr(binding.ndarray(Qarr), binding.ndarray(real_pols2), binding.ndarray(imag_pols2))
+        pols2 = real_pols2 + 1j*imag_pols2
+        self.assert_(np.allclose( np.array(pols1), pols2 ))
 
         Nq = 1000000
         Qbigarr = np.zeros((Nq, 3))
         Ebigarr = np.zeros((Nq, disp.nBranches()))
         disp.energy_arr(binding.ndarray(Qbigarr), binding.ndarray(Ebigarr))
+        realpolbigarr = np.zeros((Nq, disp.nBranches(), disp.nAtoms(), 3))
+        imagpolbigarr = np.zeros((Nq, disp.nBranches(), disp.nAtoms(), 3))
+        disp.polarization_arr(binding.ndarray(Qarr), binding.ndarray(realpolbigarr), binding.ndarray(imagpolbigarr))
         return
         
         

--- a/packages/mccomponents/tests/mccomponentsbpmodule/phonon/LinearlyInterpolatedDispersion_3D_TestCase.py
+++ b/packages/mccomponents/tests/mccomponentsbpmodule/phonon/LinearlyInterpolatedDispersion_3D_TestCase.py
@@ -20,7 +20,9 @@ debug = journal.debug( "LinearlyInterpolatedDispersion_3D_TestCase" )
 warning = journal.warning( "LinearlyInterpolatedDispersion_3D_TestCase" )
 
 
+import numpy as np
 import mcni
+from mcni import mcnibp
 from mccomposite import mccompositebp 
 from mccomponents import mccomponentsbp
 
@@ -49,6 +51,16 @@ class TestCase(unittest.TestCase):
 
         disp = mccomponentsbp.LinearlyInterpolatedDispersionOnGrid_3D_dblarrays(
             nAtoms, Qx_axis, Qy_axis, Qz_axis, eps_arr, E_arr )
+
+        print "# of branches %s, # of atoms %s" % (disp.nBranches(), disp.nAtoms())
+        Q = mcnibp.Vector3_double(0,0,0)
+        Es = [disp.energy(i, Q) for i in range(disp.nBranches())]
+
+        from mccomponents.homogeneous_scatterer.bindings import default
+        binding = default()
+        Qs = np.zeros((5,3))
+        Es = np.zeros((5, disp.nBranches()))
+        disp.energy_arr(binding.ndarray(Qs), binding.ndarray(Es))
         return
 
     pass  # end of TestCase

--- a/packages/mccomponents/tests/mccomponentsbpmodule/phonon/LinearlyInterpolatedDispersion_3D_TestCase.py
+++ b/packages/mccomponents/tests/mccomponentsbpmodule/phonon/LinearlyInterpolatedDispersion_3D_TestCase.py
@@ -61,6 +61,9 @@ class TestCase(unittest.TestCase):
         Qs = np.zeros((5,3))
         Es = np.zeros((5, disp.nBranches()))
         disp.energy_arr(binding.ndarray(Qs), binding.ndarray(Es))
+        realpols = np.zeros((5, disp.nBranches(), disp.nAtoms(), 3))
+        imagpols = np.zeros((5, disp.nBranches(), disp.nAtoms(), 3))
+        disp.polarization_arr(binding.ndarray(Qs), binding.ndarray(realpols), binding.ndarray(imagpols))
         return
 
     pass  # end of TestCase


### PR DESCRIPTION
Fixes #373 