### PR TITLE
CI: use github secret and aws secret for anaconda upload

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,11 +55,11 @@ jobs:
           ls
 
       # build and test
-      - name: set python version
-        run: echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: build / test / upload
         run: |
           echo $PYTHON_VERSION
+          conda activate test
           ./builders/aws-codebuild/build_and_test.sh
         env:
           ANACONDA_UPLOAD_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -54,3 +54,5 @@ jobs:
         run: |
           echo $PYTHON_VERSION
           ./builders/aws-codebuild/build_and_test.sh
+        env:
+          ANACONDA_UPLOAD_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          python-version: 3.8
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,9 +43,10 @@ jobs:
           conda config --add channels conda-forge
           conda config --add channels diffpy
           conda config --add channels mcvine
-      - name: conda install conda-build
+      - name: conda install conda-build and anaconda-client
         shell: pwsh
-        run: conda install -n root conda-build
+        run: |
+          conda install -n root conda-build anaconda-client
       
       # build and test
       - name: set python version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          python-version: 3.8
       - name: Conda info
         shell: bash -l {0}
         run: conda info
@@ -47,6 +48,12 @@ jobs:
         run: |
           conda install -n root conda-build
       
+      - name: checks
+        run: |
+          conda env list
+          pwd
+          ls
+
       # build and test
       - name: set python version
         run: echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          activate-environment: ""
       - name: Conda info
         shell: bash -l {0}
         run: conda info
@@ -43,15 +42,15 @@ jobs:
           conda config --add channels conda-forge
           conda config --add channels diffpy
           conda config --add channels mcvine
-      - name: conda install conda-build and anaconda-client
+      - name: conda install conda-build
         shell: pwsh
         run: |
-          conda install -n root conda-build anaconda-client
+          conda install -n root conda-build
       
       # build and test
       - name: set python version
         run: echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-      - name: build and test
+      - name: build / test / upload
         run: |
           echo $PYTHON_VERSION
           ./builders/aws-codebuild/build_and_test.sh

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,6 +49,7 @@ jobs:
           conda install -n root conda-build
       
       - name: checks
+        shell: pwsh
         run: |
           conda env list
           pwd
@@ -56,6 +57,7 @@ jobs:
 
       # build and test
       - name: build / test / upload
+        shell: pwsh
         run: |
           echo $PYTHON_VERSION
           conda activate test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,7 +60,6 @@ jobs:
         shell: pwsh
         run: |
           echo $PYTHON_VERSION
-          conda activate test
           ./builders/aws-codebuild/build_and_test.sh
         env:
           ANACONDA_UPLOAD_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.6", "2.7"]   

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,7 +55,7 @@ jobs:
           pwd
           ls
 
-      # build and test
+      # build and test (have to use pwsh!)
       - name: build / test / upload
         shell: pwsh
         run: |

--- a/builders/aws-codebuild/build_and_test.sh
+++ b/builders/aws-codebuild/build_and_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -x
+set -e
 
 #
 export PATH=$HOME/mc/bin:$PATH

--- a/builders/aws-codebuild/build_and_test.sh
+++ b/builders/aws-codebuild/build_and_test.sh
@@ -4,6 +4,7 @@ set -x
 
 #
 export PATH=$HOME/mc/bin:$PATH
+#
 export GIT_FULL_HASH=`git rev-parse HEAD`
 export GIT_VER=`git describe --tags`
 export VERSION=`git describe --tags | cut -d '-' -f1 | cut -c2-`
@@ -24,8 +25,12 @@ cat conda_build_config.yaml
 conda build --python $PYTHON_VERSION .
 
 # upload
+conda env list
 conda install anaconda-client
+conda list
+which anaconda
 conda config --set anaconda_upload no
-echo $CONDA_PREFIX_1
+CONDA_ROOT_PREFIX=$(realpath $(dirname `which conda`)/..)
+echo $CONDA_ROOT_PREFIX
 anaconda -t $ANACONDA_UPLOAD_TOKEN upload --force --label unstable \
-         $CONDA_PREFIX_1/conda-bld/linux-64/mcvine-core-$MCVINE_CONDA_PKG_VER-*.tar.bz2
+         $CONDA_ROOT_PREFIX/conda-bld/linux-64/mcvine-core-$MCVINE_CONDA_PKG_VER-*.tar.bz2

--- a/builders/aws-codebuild/build_and_test.sh
+++ b/builders/aws-codebuild/build_and_test.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
 
 set -x
+
+#
 export PATH=$HOME/mc/bin:$PATH
 export GIT_FULL_HASH=`git rev-parse HEAD`
 export GIT_VER=`git describe --tags`
-export VERSION="1.3.5"
-echo $VERSION
-export MCVINE_CONDA_PKG_VER=${VERSION}unstable
+export VERSION=`git describe --tags | cut -d '-' -f1 | cut -c2-`
+export VERSION_NEXT=`echo ${VERSION}| awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}'`
+echo $VERSION $VERSION_NEXT
+export MCVINE_CONDA_PKG_VER=${VERSION_NEXT}.dev
 echo $MCVINE_CONDA_PKG_VER
 cd builders/aws-codebuild/conda-recipe
+
+# create meta.yaml
 ./create_meta_yaml $MCVINE_CONDA_PKG_VER $GIT_FULL_HASH
 grep version meta.yaml
 grep git_rev meta.yaml
+
+# build
 cat meta.yaml
 cat conda_build_config.yaml
 conda build --python $PYTHON_VERSION .
+
+# upload
+conda install anaconda-client
+conda config --set anaconda_upload no
+echo $CONDA_PREFIX_1
+anaconda -t $ANACONDA_UPLOAD_TOKEN upload --force --label unstable \
+         $CONDA_PREFIX_1/conda-bld/linux-64/mcvine-core-$MCVINE_CONDA_PKG_VER-*.tar.bz2

--- a/builders/aws-codebuild/buildspec.yaml
+++ b/builders/aws-codebuild/buildspec.yaml
@@ -1,7 +1,9 @@
 version: 0.2
 env:
   variables:
-      DEBUG_MCVINE_BUILD: 0
+    DEBUG_MCVINE_BUILD: 0
+  secrets-manager:
+    ANACONDA_UPLOAD_TOKEN: "anaconda/mcvine:api-token"
 batch:
   fast-fail: false
   build-list:

--- a/packages/legacycomponents/mcstas2/tests/components/SNS_source/SNS_source_TestCase.py
+++ b/packages/legacycomponents/mcstas2/tests/components/SNS_source/SNS_source_TestCase.py
@@ -15,7 +15,7 @@ class SNS_source_TestCase(unittest.TestCase):
         shutil.copyfile(mod_data, fn)
         import mcvine.run_script
         mcvine.run_script.run_mpi(
-            './myinstrument.py', "out", 3e6,
+            './myinstrument.py', "out", 1e7,
             nodes=1,
             overwrite_datafiles=True,
         )

--- a/packages/legacycomponents/mcstas2/tests/components/SNS_source_r1/SNS_source_r1_TestCase.py
+++ b/packages/legacycomponents/mcstas2/tests/components/SNS_source_r1/SNS_source_r1_TestCase.py
@@ -15,7 +15,7 @@ class SNS_source_TestCase(unittest.TestCase):
         shutil.copyfile(mod_data, fn)
         import mcvine.run_script
         mcvine.run_script.run_mpi(
-            './myinstrument.py', "out", 3e6,
+            './myinstrument.py', "out", 1e7,
             nodes=1,
             overwrite_datafiles=True,
         )


### PR DESCRIPTION
* github actions spec reuse the build_and_test script for AWS codebuild spec
* use github secret and AWS secret to store anaconda access token for mcvine
* improved build_and_test script to be similar to travis CI spec
* github actions will be the main CI. AWS codebuild is the backup. travis CI most likely won't be needed anymore