### PR TITLE
save abs position and orientation in each component

### DIFF
--- a/packages/mcni/python/mcni/Instrument.py
+++ b/packages/mcni/python/mcni/Instrument.py
@@ -86,6 +86,8 @@ simulation context is an instance of SimulationContext
             position = abs(position)
             orientation = abs(orientation)
         self.geometer.register(component, position, orientation)
+        component.abs_position = self.geometer.position(component)
+        component.abs_orientation = self.geometer.orientation(component)
         return
 
     def _createGeometer(self):


### PR DESCRIPTION
this change allows a component to have the information to, for example, calculate the gravity vector