### PR TITLE
mantid upgrade 6.11

### DIFF
--- a/builders/CI/conda-recipe/conda_build_config.yaml
+++ b/builders/CI/conda-recipe/conda_build_config.yaml
@@ -3,15 +3,15 @@ python:
 gsl:
   - 2.7
 boost:
-  - 1.78
+  - 1.84
 openmpi:
   - 4.1.0
 numpy:
   - 1.24.*
 numpyext:
-  - 0.1.3
-bpext:
   - 0.1.4
+bpext:
+  - 0.1.5
 histogram:
   - 0.4.*
 pyre:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: mcvine-developer2
+name: mcvine-developer
 channels:
   - neutrons
   - mantid

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: mcvine-developer
 channels:
   - neutrons
   - mantid
+  - mcvine/label/rc
   - mcvine
   - conda-forge
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: mcvine-developer
+name: mcvine-developer2
 channels:
   - neutrons
   - mantid
@@ -12,7 +12,7 @@ dependencies:
   - conda-verify
   - python
   - python_abi
-  - mantid =6.*
+  - mantid =6.11
   - jupyter
   - numpy
   - pillow
@@ -23,7 +23,7 @@ dependencies:
   - danse.ins.dsm
   - danse.ins.numpyext
   - danse.ins.bpext
-  - diffpy.Structure
+  - diffpy.Structure=3.0.1 
   - histogram
   - pyre == 0.8.3
   - gsl


### PR DESCRIPTION
This updates the environment.yaml  to include mantid 6.11 specifically as a depedency and be consistent with the associated mcvine-core package.
When it is approved it will be tagged with v1.5.1rc2