### PR TITLE
Replaced try block with one line imports

### DIFF
--- a/packages/legacycomponents/mcstas2/python/mcstas2/utils/carray.py
+++ b/packages/legacycomponents/mcstas2/python/mcstas2/utils/carray.py
@@ -13,12 +13,7 @@
 
 
 
-try:
-    from danse.ins import bpext
-except ImportError:
-    import bpext
-    import warnings
-    warnings.warn("Using old bpext. Should use danse.ins.bpext")
+from danse.ins import bpext
 
 
 def pycptr2npyarr( vptr, typename, size ):

--- a/packages/mccomponents/python/mccomponents/sample/phonon/bindings/BoostPythonBinding.py
+++ b/packages/mccomponents/python/mccomponents/sample/phonon/bindings/BoostPythonBinding.py
@@ -29,12 +29,7 @@ except ImportError:
     import warnings
     warnings.warn("Using old numpyext. Should use danse.ins.numpyext")
 
-try:
-    from danse.ins import bpext
-except ImportError:
-    import bpext
-    import warnings
-    warnings.warn("Using old bpext. Should use danse.ins.bpext")
+from danse.ins import bpext
 
 
 class New:

--- a/packages/mccomponents/python/mccomponents/sample/sans/bindings/BoostPythonBinding.py
+++ b/packages/mccomponents/python/mccomponents/sample/sans/bindings/BoostPythonBinding.py
@@ -17,12 +17,7 @@ except ImportError:
     import warnings
     warnings.warn("Using old numpyext. Should use danse.ins.numpyext")
 
-try:
-    from danse.ins import bpext
-except ImportError:
-    import bpext
-    import warnings
-    warnings.warn("Using old bpext. Should use danse.ins.bpext")
+from danse.ins import bpext
 
 
 class New:

--- a/packages/mccomponents/tests/mccomponentsbpmodule/phonon/NdArray_TestCase.py
+++ b/packages/mccomponents/tests/mccomponentsbpmodule/phonon/NdArray_TestCase.py
@@ -31,12 +31,7 @@ except ImportError:
     import numpyext
     import warnings
     warnings.warn("Using old numpyext. Should use danse.ins.numpyext")
-try:
-    from danse.ins import bpext
-except ImportError:
-    import bpext
-    import warnings
-    warnings.warn("Using old bpext. Should use danse.ins.bpext")
+from danse.ins import bpext
 
 
 class TestCase(unittest.TestCase):

--- a/packages/mcni/python/mcni/bindings/boostpython/__init__.py
+++ b/packages/mcni/python/mcni/bindings/boostpython/__init__.py
@@ -85,12 +85,7 @@ def _import():
     import mcni.mcnibp
     from . import _patch_neutronevents_bp_interface
     import mcni._mcni
-    try:
-        from danse.ins import bpext
-    except ImportError:
-        import bpext
-        import warnings
-        warnings.warn("Using old bpext. Should use danse.ins.bpext\n%s")
+    from danse.ins import bpext
     return
 
 try:

--- a/packages/mcni/python/mcni/bindings/boostpython/_patch_neutronevents_bp_interface.py
+++ b/packages/mcni/python/mcni/bindings/boostpython/_patch_neutronevents_bp_interface.py
@@ -102,12 +102,7 @@ def cevents_from_npyarr(npyarr):
         warnings.warn("Using old numpyext. Should use danse.ins.numpyext")
     
     ptr = getdataptr( npyarr )
-    try:
-        from danse.ins import bpext
-    except ImportError:
-        import bpext
-        import warnings
-        warnings.warn("Using old bpext. Should use danse.ins.bpext")
+    from danse.ins import bpext
     import mcni._mcni
     cevents = bpext.wrap_ptr( ptr, 'cNeutronEvent' )
     cevents.origin = npyarr

--- a/packages/mcni/tests/mcnimodule/mcnimodule_TestCase.py
+++ b/packages/mcni/tests/mcnimodule/mcnimodule_TestCase.py
@@ -28,12 +28,7 @@ except ImportError:
     from numpyext import getdataptr
     import warnings
     warnings.warn("Using old numpyext. Should use danse.ins.numpyext")
-try:
-    from danse.ins import bpext
-except ImportError:
-    import bpext
-    import warnings
-    warnings.warn("Using old bpext. Should use danse.ins.bpext")
+from danse.ins import bpext
 
 
 class mcnimodule_TestCase(unittest.TestCase):


### PR DESCRIPTION
This PR is just replacing try blocks with a single line import. Functionality should still be the same.

EWM item: [11169](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11169) 