### PR TITLE
Removed references to journal from C++ files

### DIFF
--- a/packages/legacycomponents/mcstas2/lib/exception.h
+++ b/packages/legacycomponents/mcstas2/lib/exception.h
@@ -25,11 +25,6 @@
 #include <exception>
 #endif
 
-#ifndef JOURNAL_ERROR_H_INCLUDED
-#define JOURNAL_ERROR_H_INCLUDED
-#include "journal/error.h"
-#endif
-
 
 #include <sstream>
 namespace mcstas2{

--- a/packages/mccomponents/lib/homogeneous_scatterer/DGSSXResPixel.cc
+++ b/packages/mccomponents/lib/homogeneous_scatterer/DGSSXResPixel.cc
@@ -13,10 +13,6 @@
 // #define DEBUG
 // #define DEBUG2  // for debugging distribution of random x (position along path)
 
-#ifdef DEBUG
-// #include "portinfo"
-#include "journal/debug.h"
-#endif
 
 #ifdef DEBUG2
 #include "mcni/neutron/units_conversion.h"
@@ -56,9 +52,6 @@ mccomponents::DGSSXResPixel::DGSSXResPixel
 mccomponents::DGSSXResPixel::InteractionType
 mccomponents::DGSSXResPixel::interact_path1(mcni::Neutron::Event &ev)
 {
-#ifdef DEBUG
-  journal::debug_t debug(DGSSXResPixel_Impl::jrnltag);
-#endif
 
   using namespace mccomposite;
 

--- a/packages/mccomponents/lib/homogeneous_scatterer/HomogeneousNeutronScatterer.cc
+++ b/packages/mccomponents/lib/homogeneous_scatterer/HomogeneousNeutronScatterer.cc
@@ -23,10 +23,6 @@
 // #define DEBUG
 // #define DEBUG2  // for debugging distribution of random x (position along path)
 
-#ifdef DEBUG
-// #include "portinfo"
-#include "journal/debug.h"
-#endif
 
 #ifdef DEBUG2
 #include "mcni/neutron/units_conversion.h"
@@ -98,9 +94,6 @@ mccomponents::HomogeneousNeutronScatterer::mu
 mccomponents::HomogeneousNeutronScatterer::InteractionType
 mccomponents::HomogeneousNeutronScatterer::interact_path1(mcni::Neutron::Event &ev)
 {
-#ifdef DEBUG
-  journal::debug_t debug(HomogeneousNeutronScatterer_Impl::jrnltag);
-#endif
 
   using namespace mccomposite;
   
@@ -111,21 +104,8 @@ mccomponents::HomogeneousNeutronScatterer::interact_path1(mcni::Neutron::Event &
   // but if it is outside, we need to propagate to the front surface 
   // of the shape.
   if (location != geometry::Locator::inside ) {
-#ifdef DEBUG
-    debug << journal::at(__HERE__) 
-	  << "event " << ev << " is outsid of the shape " << shape() << journal::newline;
-    debug << "need propagation" << journal::endl;
-#endif
     propagate_to_next_incident_surface(ev, shape());
-#ifdef DEBUG
-    debug << journal::at(__HERE__) 
-	  << "event propagated. new position" << ev.state.position << journal::endl;
-#endif
   } else {
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "event " << ev << " is inside the shape " << shape() << journal::endl;
-#endif
   }
   // tof before exiting the shape for the first time
   double tof = tof_before_exit( ev, shape() );
@@ -153,14 +133,6 @@ mccomponents::HomogeneousNeutronScatterer::interact_path1(mcni::Neutron::Event &
 
   double r = math::random(0., sum_of_weights);
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "random number = " << r
-	<< "marks = " << transmission_mark << ", "
-	<< absorption_mark << ", "
-	<< sum_of_weights 
-	<< journal::endl;
-#endif
 
   if (r < transmission_mark) {
     // transmission
@@ -173,27 +145,8 @@ mccomponents::HomogeneousNeutronScatterer::interact_path1(mcni::Neutron::Event &
     // absorption
     double x = math::random(0., distance);
     double prob = mu * distance * std::exp( -(mu+sigma) * x );
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "original probability = " << ev.probability << ", "
-	<< "mu = " << mu << ", "
-	<< "sigma = " << sigma << ", "
-	<< "distance = " << distance << ", "
-	<< "probability to propagate to x = " << x << " is " << prob
-	<< journal::endl;
-#endif
     ev.probability *= prob * (sum_of_weights/m_weights.absorption);
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "adjusted probability = " << ev.probability
-	<< journal::endl;
-#endif
     propagate( ev, x/velocity );
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "propagated. neutron is now " << ev
-	<< journal::endl;
-#endif
     m_kernel.absorb( ev );
 
     ev.probability = -1;
@@ -222,61 +175,16 @@ mccomponents::HomogeneousNeutronScatterer::interact_path1(mcni::Neutron::Event &
     //           and sigma for scattering.
     double prob = distance * atten;
     prob *= sum_of_weights/m_weights.scattering;
-#ifdef DEBUG
-    debug
-      << journal::at(__HERE__)
-      << "sigma, distance, attenuation: "
-      << sigma << ", " << distance << ", " << atten
-      << "prob factor: " << prob 
-      << journal::endl;
-#endif
-#ifdef DEBUG2
-    typedef mcni::Vector3<double> V3d;
-    debug
-      << journal::at(__HERE__)
-      << "p0=" << ev.probability << ", "
-      << "distance=" << distance << ", "
-      << "x=" << x << ", "
-      << "atten=" << atten << ", "
-      << journal::newline
-      ;
-#endif
     ev.probability *= prob;
-#ifdef DEBUG2
-    debug
-      << journal::at(__HERE__)
-      << "p1=" << ev.probability << ","
-      << journal::newline
-      ;
-    V3d vi = ev.state.velocity;
-#endif
     propagate( ev, x/velocity );
     m_kernel.scatter( ev );
     ev.probability *= packing_factor;
-#ifdef DEBUG2
-    V3d vf = ev.state.velocity;
-    V3d vQ = vi - vf;
-    double Q = mcni::neutron_units_conversion::v2k * vQ.length();
-    debug
-      << journal::at(__HERE__)
-      << "p2=" << ev.probability << ","
-      << "Q=" << Q << ","
-      << journal::newline
-      ;
-#endif
     mcni::Neutron::Event save = ev;
     if (ev.probability <=0) 
       return base_t::absorption;
     propagate_to_next_exiting_surface( ev, shape() );
     double atten2 = calculate_attenuation( save, ev.state.position );
     ev.probability *= atten2;
-#ifdef DEBUG2
-    debug
-      << journal::at(__HERE__)
-      << "atten2=" << atten2 << ","
-      << "p3=" << ev.probability << "," 
-      << journal::endl;
-#endif
     return base_t::scattering;
   }
   
@@ -288,9 +196,6 @@ void
 mccomponents::HomogeneousNeutronScatterer::_interactM1
 (const mcni::Neutron::Event &ev, mcni::Neutron::Events & evts)
 {
-#ifdef DEBUG
-  journal::debug_t debug(HomogeneousNeutronScatterer_Impl::jrnltag);
-#endif
 
 //   std::cout << "_interactM1: " 
 // 	    << "input neutron = " << ev << ", "
@@ -308,21 +213,8 @@ mccomponents::HomogeneousNeutronScatterer::_interactM1
   // but if it is outside, we need to propagate to the front surface 
   // of the shape.
   if (location != geometry::Locator::inside ) {
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "event " << original << " is outsid of the shape " << shape() << journal::newline;
-    debug << "need propagation" << journal::endl;
-#endif
     propagate_to_next_incident_surface(original, shape());
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "event propagated. new position" << original.state.position << journal::endl;
-#endif
   } else {
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "event " << original << " is inside the shape " << shape() << journal::endl;
-#endif
   }
 
   // tof before exiting the shape for the first time
@@ -347,18 +239,8 @@ mccomponents::HomogeneousNeutronScatterer::_interactM1
   
   // transmission
   ev1 = original;
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "* Transmission: propagate" << original << " out of " << shape()
-	<< journal::endl;
-#endif
   propagate_to_next_exiting_surface( ev1, shape() );
   ev1.probability *= transmission_prob;
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "* Transmission continue 1: propagated event: " << ev1
-	<< journal::endl;
-#endif
   evts.push_back( ev1 );
 
 //   std::cout << "1. evts = " << evts << std::endl;
@@ -366,11 +248,6 @@ mccomponents::HomogeneousNeutronScatterer::_interactM1
   // absorption
   ev1 = original;
   ev1.probability *= absorption_prob;
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "* Absorption: absorbed event " << ev1
-	  << journal::endl;
-#endif
   m_kernel.absorb( ev1 );
 
   // scattering
@@ -384,19 +261,8 @@ mccomponents::HomogeneousNeutronScatterer::_interactM1
   double prob = distance * std::exp( -(mu+sigma) * x );
   ev1.probability *= prob;
   propagate( ev1, x/velocity );
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "* Scattering: event propagated to " << ev1
-	  << " to be scattered"
-	  << journal::endl;
-#endif
   m_kernel.scatter( ev1 );
   ev1.probability *= packing_factor;
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "* Scattering continue 1: event scattered " << ev1
-	  << journal::endl;
-#endif
   evts.push_back( ev1 );
 
 //   std::cout << "_interactM1: " 
@@ -412,10 +278,6 @@ mccomponents::HomogeneousNeutronScatterer::InteractionType
 mccomponents::HomogeneousNeutronScatterer::interactM_path1
 (const mcni::Neutron::Event &ev, mcni::Neutron::Events &evts)
 {
-#ifdef DEBUG
-  journal::debug_t debug(HomogeneousNeutronScatterer_Impl::jrnltag);
-#endif
-
   using namespace mccomposite;
 
   mcni::Neutron::Events to_be_scattered, scattered;
@@ -423,47 +285,20 @@ mccomponents::HomogeneousNeutronScatterer::interactM_path1
   
   int nloop = 0;
   while (to_be_scattered.size() && nloop++ < max_scattering_loops) {
-
-#ifdef DEBUG
-    debug <<  journal::at(__HERE__)
-	  << "interactM_path1: "
-	  << "to_be_scattered = " << to_be_scattered
-	  << journal::endl;
-#endif
-    
     mcni::Neutron::Events to_be_scattered2;
 
     for (size_t neutron_index = 0; neutron_index < to_be_scattered.size(); neutron_index++) {
       
       const mcni::Neutron::Event & ev1 = to_be_scattered[neutron_index];
-#ifdef DEBUG
-      debug <<  journal::at(__HERE__)
-	    << "event to scatter is " << ev1
-	    << journal::newline;
-#endif
       
       // if neutron probability is low, skip
       if (ev1.probability >= 0 && ev1.probability < min_neutron_probability) {
-#ifdef DEBUG
-	debug <<  journal::at(__HERE__)
-	      << "probability too low. skip"
-	      << journal::endl;
-#endif      
 	continue;
       }
       
       scattered.clear();
       // interact once
       _interactM1( ev1, scattered );
-#ifdef DEBUG
-	debug <<  journal::at(__HERE__)
-	      << "event " << ev1 
-	      << " got scattered into " << scattered
-	      << journal::newline
-	      << "now looping over these new neutrons "
-	      << journal::endl
-	  ;
-#endif      
       
       // loop over scattered neutron and deal with each of them
       for (size_t scattered_neutron_index = 0;
@@ -474,36 +309,18 @@ mccomponents::HomogeneousNeutronScatterer::interactM_path1
 	
 	// if the probability is too low, we just absorb it and done
 	if (ev2.probability < minimum_neutron_event_probability) {
-#ifdef DEBUG
-	  debug << journal::at(__HERE__)
-		<< "event " << ev2 << " has a very low probability, "
-		<< "will be dicarded"
-		<< journal::endl;
-#endif
 	  // nothing to do actually
 	  continue;
 	}
 
 	// if it is on border or outside, we are done with it here
 	if (locate(ev2, shape()) != geometry::Locator::inside) {
-#ifdef DEBUG
-	  debug << journal::at(__HERE__)
-		<< "event " << ev2 << " is not inside."
-		<< "It will be saved"
-		<< journal::endl;
-#endif
 	  evts.push_back( ev2 );
 	  continue;
 	}
 	
 	// this means the event is inside the scatterer
 	// add this event to a new "to-be-scattered" list
-#ifdef DEBUG
-	debug << journal::at(__HERE__)
-	      << "event " << ev2 << " is still inside. "
-	      << "It will be scattered again"
-	      << journal::endl;
-#endif
 	to_be_scattered2.push_back( ev2 );
 	
       } // loop over scattered neutrons
@@ -511,21 +328,9 @@ mccomponents::HomogeneousNeutronScatterer::interactM_path1
     } // loop over neutrons to be scattered
     
     to_be_scattered2.swap( to_be_scattered );
-#ifdef DEBUG
-	debug << journal::at(__HERE__)
-	      << "neutrons for next round of scattering: "
-	      << to_be_scattered
-	      << journal::endl;
-#endif
     
   } // while there are still neutrons to be scattered
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "left over neutrons: "
-	<< to_be_scattered
-	<< journal::endl;
-#endif
   for (int i=0; i<to_be_scattered.size(); i++)
     evts.push_back(to_be_scattered[i]);
   

--- a/packages/mccomponents/lib/kernels/IsotropicKernel.cc
+++ b/packages/mccomponents/lib/kernels/IsotropicKernel.cc
@@ -18,24 +18,10 @@
 #include "mccomponents/math/random.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 struct mccomponents::kernels::IsotropicKernel::Details {
-
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
 };
-
-
-#ifdef DEBUG
-const char mccomponents::kernels::IsotropicKernel::Details::jrnltag[] = "IsotropicKernel";
-#endif
 
 
 mccomponents::kernels::IsotropicKernel::IsotropicKernel
@@ -78,10 +64,6 @@ void
 mccomponents::kernels::IsotropicKernel::S
 ( mcni::Neutron::Event & ev )
 {
-#ifdef DEBUG
-  m_details->debug << "in" << ev << journal::endl;
-#endif
-
   // input neutron state
   mcni::Neutron::State & state = ev.state;
   // incident neutron velocity
@@ -90,13 +72,6 @@ mccomponents::kernels::IsotropicKernel::S
   // theta, phi
   double theta = math::random(0., mcni::PI);
   double phi = math::random(0., mcni::PI*2);
-
-#ifdef DEBUG
-  m_details->debug
-    << "theta: " << theta << ", "
-    << "phi: " << phi << ", "
-    << journal::endl;
-#endif
 
   // scattered neutron velocity vector
   double vx = vi*sin(theta)*cos(phi);
@@ -111,12 +86,6 @@ mccomponents::kernels::IsotropicKernel::S
   V3d vf(vx,vy,vz);
   state.velocity = vf;
   
-#ifdef DEBUG
-  m_details->debug
-    << "out" << ev
-    << journal::endl;
-#endif
-
 }
 
 

--- a/packages/mccomponents/lib/kernels/detector/EventModeMCA.cc
+++ b/packages/mccomponents/lib/kernels/detector/EventModeMCA.cc
@@ -13,11 +13,11 @@
 
 
 #include <cassert>
+#include <sstream>
 
 #include "mccomponents/kernels/detector/EventModeMCA.h"
 #include "mccomposite/vector2ostream.h"
 #include "mccomponents/exception.h"
-#include "journal/debug.h"
 
 
 namespace mccomponents {
@@ -38,22 +38,10 @@ mccomponents::detector::EventModeMCA::EventModeMCA
   : m_out( outfilename, std::ofstream::binary ),
     m_dims( dims )
 {
-  // #ifdef DEBUG
-  journal::debug_t debug( EventModeMCA_impl::jrnltag );
-  debug << journal::at(__HERE__)
-	<< "Opening event mode mca" << journal::newline
-	<< "output file name: " << outfilename 
-	<< journal::endl;
-
-  // #endif
 }
 
 mccomponents::detector::EventModeMCA::~EventModeMCA()
 {
-  journal::debug_t debug( EventModeMCA_impl::jrnltag );
-  debug << journal::at(__HERE__)
-	<< "Closing event mode mca" 
-	<< journal::endl;
   m_out.flush();
   m_out.close();
 }
@@ -61,26 +49,12 @@ mccomponents::detector::EventModeMCA::~EventModeMCA()
 void mccomponents::detector::EventModeMCA::accept
 ( const channels_t & channels, double n )
 {
-  
-#ifdef DEBUG
-  journal::debug_t debug( EventModeMCA_impl::jrnltag );
-  debug << journal::at(__HERE__)
-	<< "channels: ";
-  for (size_t i=0; i<channels.size(); i++) debug << channels[i] << ", ";
-  debug << journal::newline;
-  debug << "n = " << n 
-	<< journal::endl;
-#endif
-
   if  (channels.size()!=m_dims.size()+1) {
     std::ostringstream oss;
     oss << "Value error. Test of channels.size()==m_dims.size()+1 failed. ";
     oss << "channels = " << channels << ", "
 	<< "dims = " << m_dims
 	<< ".";
-#ifdef DEBUG
-    debug << journal::at(__HERE__) << oss.str() << journal::endl;
-#endif
     throw Exception( oss.str().c_str() );
   }
   
@@ -94,9 +68,6 @@ void mccomponents::detector::EventModeMCA::accept
 	  << "channel number = " << channels[i] << ", "
 	  << "dimension = " << m_dims[i]
 	  << ".";
-#ifdef DEBUG
-      debug << journal::at(__HERE__) << oss.str() << journal::endl;
-#endif
       throw Exception( oss.str().c_str() );
     }
   }
@@ -111,16 +82,6 @@ void mccomponents::detector::EventModeMCA::accept
 
   m_buffer.tofChannelNo = channels[channels.size()-1];
   m_buffer.n = n;
-
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "about to write  "
-	<< "pixelID=" << m_buffer.pixelID << ", "
-	<< "tofChannelNo=" << m_buffer.tofChannelNo << ", "
-	<< "n=" << m_buffer.n << ", "
-	<< journal::endl
-    ;
-#endif
 
   m_out.write( (const char *)&m_buffer, sizeof(m_buffer) );
 }

--- a/packages/mccomponents/lib/kernels/detector/He3.cc
+++ b/packages/mccomponents/lib/kernels/detector/He3.cc
@@ -12,7 +12,6 @@
 //
 
 
-#include "journal/warning.h"
 #include "mccomponents/kernels/detector/He3.h"
 #include "mccomponents/exception.h"
 
@@ -43,11 +42,6 @@ mccomponents::kernels::He3::scattering_coefficient( const mcni::Neutron::Event &
 void
 mccomponents::kernels::He3::scatter( mcni::Neutron::Event & ev )
 {
-  journal::warning_t warning("He3");
-  warning << journal::at(__HERE__)
-          << "He3 detector don't scatter neutrons"
-          << journal::endl;
-  return;
 }
 
     

--- a/packages/mccomponents/lib/kernels/detector/He3Tube.cc
+++ b/packages/mccomponents/lib/kernels/detector/He3Tube.cc
@@ -12,8 +12,6 @@
 //
 
 
-#include "journal/debug.h"
-
 #include "mccomponents/kernels/detector/He3Tube.h"
 
 
@@ -41,13 +39,6 @@ void
 mccomponents::kernels::He3Tube::absorb
 ( mcni::Neutron::Event & ev )
 {
-#ifdef DEBUG
-  journal::debug_t debug( He3Tube_impl::jrnltag );
-  debug << journal::at(__HERE__)
-	<< "event: " << ev
-	<< journal::endl;
-#endif
-  
   channels_t channels = m_tube_channels;
   channels.push_back( m_z2channel( ev.state.position ) );
   channels.push_back( m_tof2channel( ev.time ) );

--- a/packages/mccomponents/lib/kernels/sample/Broadened_E_Q_Kernel.icc
+++ b/packages/mccomponents/lib/kernels/sample/Broadened_E_Q_Kernel.icc
@@ -27,9 +27,6 @@
 
 
 #define DEBUG
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 #define checkNAN(name, x)   if ((x)!=(x)) std::cerr << name << " is nan" << std::endl;
@@ -42,12 +39,8 @@ mccomponents::kernels::Broadened_E_Q_Kernel<E_Q_functor_t, S_Q_functor_t, Sigma_
 
 #ifdef DEBUG
   const static char jrnltag[];
-  journal::debug_t debug;
 #endif
   Details()
-#ifdef DEBUG
-    : debug( jrnltag )
-#endif
   {}
   
   // data

--- a/packages/mccomponents/lib/kernels/sample/ConstantEnergyTransferKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/ConstantEnergyTransferKernel.cc
@@ -20,17 +20,11 @@
 #include "mccomponents/exception.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 struct mccomponents::kernels::ConstantEnergyTransferKernel::Details {
 
 #ifdef DEBUG
   const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
 #endif
 };
 

--- a/packages/mccomponents/lib/kernels/sample/ConstantQEKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/ConstantQEKernel.cc
@@ -19,17 +19,11 @@
 #include "mccomponents/math/random.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 struct mccomponents::kernels::ConstantQEKernel::Details {
 
 #ifdef DEBUG
   const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
 #endif
   
   // data

--- a/packages/mccomponents/lib/kernels/sample/ConstantvQEKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/ConstantvQEKernel.cc
@@ -20,24 +20,13 @@
 #include "mccomponents/math/random.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 struct mccomponents::kernels::ConstantvQEKernel::Details {
 
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
 };
 
 
-#ifdef DEBUG
-const char mccomponents::kernels::ConstantvQEKernel::Details::jrnltag[] = "ConstantvQEKernel";
-#endif
 
 
 mccomponents::kernels::ConstantvQEKernel::ConstantvQEKernel

--- a/packages/mccomponents/lib/kernels/sample/DGSSXResKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/DGSSXResKernel.cc
@@ -11,9 +11,6 @@
 #include "DGSSXResKernel.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 namespace mccomponents{
@@ -27,21 +24,9 @@ mccomponents::kernels::DGSSXResKernel::Details {
 
   typedef mccomponents::kernels::DGSSXResKernel kernel_t;
 
-  /*
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-#endif
-  */
-
   Details(kernel_t &i_kernel)
     :
     kernel(&i_kernel)
-    /*
-#ifdef DEBUG
-    ,debug( jrnltag )
-#endif
-    */
     {}
 
   kernel_t * kernel;

--- a/packages/mccomponents/lib/kernels/sample/E_Q_Kernel.icc
+++ b/packages/mccomponents/lib/kernels/sample/E_Q_Kernel.icc
@@ -21,10 +21,6 @@
 // debug
 // #define DEBUG
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 template< typename E_Q_functor_t, typename S_Q_functor_t>
 struct
@@ -33,8 +29,6 @@ mccomponents::kernels::E_Q_Kernel<E_Q_functor_t, S_Q_functor_t>\
 
 #ifdef DEBUG
   const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
 #endif
 
   const static double m_epsilon;

--- a/packages/mccomponents/lib/kernels/sample/E_Q_Kernel.icc.random-direction
+++ b/packages/mccomponents/lib/kernels/sample/E_Q_Kernel.icc.random-direction
@@ -26,10 +26,6 @@
 #include "mccomponents/math/rootfinding.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 template< typename E_Q_functor_t, typename S_Q_functor_t>
 struct 
@@ -41,16 +37,12 @@ mccomponents::kernels::E_Q_Kernel<E_Q_functor_t, S_Q_functor_t>\
     
 #ifdef DEBUG
   const static char jrnltag[];
-  journal::debug_t debug;
 #endif
   Details(kernel_t &i_kernel) 
     :
     kernel(&i_kernel)
     ,root_finder(1e-6)
     ,roots_finder(root_finder, 10000)
-#ifdef DEBUG
-    ,debug( jrnltag )
-#endif
     {}
 
   kernel_t * kernel;

--- a/packages/mccomponents/lib/kernels/sample/E_Q_Kernel.icc.random-direction-solve-Ef
+++ b/packages/mccomponents/lib/kernels/sample/E_Q_Kernel.icc.random-direction-solve-Ef
@@ -23,11 +23,7 @@ Implementation documentation: https://github.com/mcvine/training/blob/7d985bec0b
 #include "mccomponents/math/rootfinding.h"
 
 
-// #define DEBUG
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 template< typename E_Q_functor_t, typename S_Q_functor_t>
@@ -38,18 +34,11 @@ mccomponents::kernels::E_Q_Kernel<E_Q_functor_t, S_Q_functor_t>\
   typedef mccomponents::kernels::E_Q_Kernel<E_Q_functor_t, S_Q_functor_t> \
     kernel_t;
     
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-#endif
   Details(kernel_t &i_kernel) 
     :
     kernel(&i_kernel)
     ,root_finder(1e-2)
     ,roots_finder(root_finder, num_sections())
-#ifdef DEBUG
-    ,debug( jrnltag )
-#endif
     {}
 
   kernel_t * kernel;

--- a/packages/mccomponents/lib/kernels/sample/E_vQ_Kernel.icc
+++ b/packages/mccomponents/lib/kernels/sample/E_vQ_Kernel.icc
@@ -26,10 +26,6 @@
 #include "mccomponents/math/rootfinding.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 namespace mccomponents{
   namespace kernels{
@@ -45,19 +41,12 @@ mccomponents::kernels::E_vQ_Kernel<E_vQ_functor_t, S_vQ_functor_t>\
   typedef mccomponents::kernels::E_vQ_Kernel<E_vQ_functor_t, S_vQ_functor_t> \
     kernel_t;
     
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-#endif
   
   Details(kernel_t &i_kernel) 
     :
     kernel(&i_kernel)
     ,root_finder(1e-3)
     ,roots_finder(root_finder, 1000)
-#ifdef DEBUG
-    ,debug( jrnltag )
-#endif
     {}
 
   kernel_t * kernel;
@@ -104,14 +93,6 @@ struct E_vq_minus_deltaE: public mccomponents::math::Functor {
   v3_t vki, ukf;
   E_vQ_functor_t &E_vQ;  
 };
-
-
-#ifdef DEBUG
-template< typename E_vQ_functor_t, typename S_vQ_functor_t>
-const char 
-mccomponents::kernels::E_vQ_Kernel<E_vQ_functor_t, S_vQ_functor_t>\
-::Details::jrnltag[] = "E_vQ_Kernel";
-#endif
 
 
 template< typename E_vQ_functor_t, typename S_vQ_functor_t>

--- a/packages/mccomponents/lib/kernels/sample/LorentzianBroadened_E_Q_Kernel.icc
+++ b/packages/mccomponents/lib/kernels/sample/LorentzianBroadened_E_Q_Kernel.icc
@@ -17,9 +17,6 @@
 
 
 #define DEBUG
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 #define checkNAN(name, x)   if ((x)!=(x)) std::cerr << name << " is nan" << std::endl;
@@ -30,27 +27,13 @@ struct
 mccomponents::kernels::LorentzianBroadened_E_Q_Kernel<E_Q_functor_t, S_Q_functor_t, Gamma_Q_functor_t>\
 :: Details {
 
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-#endif
   Details()
-#ifdef DEBUG
-    : debug( jrnltag )
-#endif
   {}
 
   // data
   const static double m_epsilon;
 };
 
-
-#ifdef DEBUG
-template< typename E_Q_functor_t, typename S_Q_functor_t, typename Gamma_Q_functor_t>
-const char
-mccomponents::kernels::LorentzianBroadened_E_Q_Kernel<E_Q_functor_t, S_Q_functor_t, Gamma_Q_functor_t>\
-::Details::jrnltag[] = "LorentzianBroadened_E_Q_Kernel";
-#endif
 
 template< typename E_Q_functor_t, typename S_Q_functor_t, typename Gamma_Q_functor_t>
 const double mccomponents::kernels::LorentzianBroadened_E_Q_Kernel<E_Q_functor_t, S_Q_functor_t, Gamma_Q_functor_t> \

--- a/packages/mccomponents/lib/kernels/sample/SANS/SpheresKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/SANS/SpheresKernel.cc
@@ -11,24 +11,11 @@
 #include "mccomponents/math/random/geometry.h"
 #include "mccomponents/kernels/sample/SANS/SpheresKernel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 struct mccomponents::kernels::SANSSpheresKernel::Details {
 
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
 };
 
-
-#ifdef DEBUG
-const char mccomponents::kernels::SANSSpheresKernel::Details::jrnltag[] = "SANSSpheresKernel";
-#endif
 
 
 mccomponents::kernels::SANSSpheresKernel::SANSSpheresKernel

--- a/packages/mccomponents/lib/kernels/sample/SQE_EnergyFocusing_Kernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/SQE_EnergyFocusing_Kernel.cc
@@ -11,25 +11,7 @@
 #include "mccomponents/math/random.h"
 #include "mccomponents/physics/constants.h"
 
-// #define DEBUG
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
-
-struct mccomponents::kernels::SQE_EnergyFocusing_Kernel::Details {
-
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
-};
-
-
-#ifdef DEBUG
-const char mccomponents::kernels::SQE_EnergyFocusing_Kernel::Details::jrnltag[] = "SQE_EnergyFocusing_Kernel";
-#endif
 
 
 mccomponents::kernels::SQE_EnergyFocusing_Kernel::SQE_EnergyFocusing_Kernel
@@ -48,8 +30,7 @@ mccomponents::kernels::SQE_EnergyFocusing_Kernel::SQE_EnergyFocusing_Kernel
     m_Qmin(Qmin), m_Qmax(Qmax), m_DQ(Qmax-Qmin),
     m_Emin(Emin), m_Emax(Emax), m_DE(Emax-Emin),
     m_Ef(Ef), m_dEf(dEf),
-    m_sqe(sqe),
-    m_details( new Details )
+    m_sqe(sqe)
 {
   // std::cout << "E range" << m_Emin << ", " << m_Emax << std::endl;
 }
@@ -103,14 +84,6 @@ mccomponents::kernels::SQE_EnergyFocusing_Kernel::S
   if (m_Emin > Ei) return; // if Ei is too small, won't scatter. nothing happen
   double Emin = std::max(m_Emin, Emin1), Emax = std::min(Emax1, std::min(Ei, m_Emax));
   E = math::random( Emin, Emax );
-#ifdef DEBUG
-  m_details->debug
-    << journal::at(__HERE__)
-    << "Original probability" << ev.probability << journal::newline
-    << "generate E between " << m_Emin << " and " << std::min(Ei, m_Emax)
-    << ", E=" << E
-    << journal::endl;
-#endif
 
   // final energy, wave vector
   double Ef = Ei - E;
@@ -122,28 +95,10 @@ mccomponents::kernels::SQE_EnergyFocusing_Kernel::S
     Qmax = std::min(m_Qmax, ki+kf);
   if (Qmax<Qmin) return; // no scatter
   double Q = math::random(Qmin, Qmax);
-#ifdef DEBUG
-  m_details->debug
-    << journal::at(__HERE__)
-    << "generate Q between " << Qmin << " and " << Qmax
-    << ", Q=" << Q
-    << journal::endl;
-#endif
 
   // adjust probability of neutron event
   double prob_mul = m_sqe(Q,E) * Q * (Qmax-Qmin) * (Emax-Emin) / (2*ki*ki);
   ev.probability *= prob_mul;
-#ifdef DEBUG
-  m_details->debug
-    << journal::at(__HERE__)
-    << "Q, E="<< Q << ", " << E << ", " << journal::endl
-    << "Qmin, Qmax=" << Qmin << ", " << Qmax << ", " << journal::endl
-    << "Emin, Emax=" << Emin << ", " << Emax << ", " << journal::endl
-    << "ki=" << ki << ", " << journal::endl
-    << "S=" << m_sqe(Q,E) << journal::endl
-    << "prob mul=" << prob_mul << journal::endl
-    << journal::endl;
-#endif
   // figure out the direction of the out-going neutron
   double cost = (kf*kf + ki*ki - Q*Q)/2/kf/ki;
 
@@ -168,16 +123,6 @@ mccomponents::kernels::SQE_EnergyFocusing_Kernel::S
 
   V3d e3 = e1 * e2;
   V3d ekf = e1*cost + e2*sint*cosp + e3 *sint*sinp;
-#ifdef DEBUG
-  m_details->debug
-    << journal::at(__HERE__)
-    << "e1 = " << e1 << journal::newline
-    << "e2 = " << e2 << journal::newline
-    << "e3 = " << e3 << journal::newline
-    << "ekf = " << ekf << journal::newline
-    << "prob = " << ev.probability << journal::newline
-    << journal::endl;
-#endif
   ev.state.velocity = ekf * (kf*conversion::k2v);
 }
 

--- a/packages/mccomponents/lib/kernels/sample/SQEkernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/SQEkernel.cc
@@ -19,18 +19,10 @@
 #include "mccomponents/math/random.h"
 #include "mccomponents/physics/constants.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 struct mccomponents::kernels::SQEkernel::Details {
 
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
 };
 
 
@@ -104,13 +96,6 @@ mccomponents::kernels::SQEkernel::S
   if (m_Emin > Ei) return; // if Ei is too small, won't scatter. nothing happen
   double Emin = m_Emin, Emax = std::min(Ei, m_Emax);
   E = math::random( Emin, Emax );
-#ifdef DEBUG
-  m_details->debug 
-    << journal::at(__HERE__)
-    << "generate E between " << m_Emin << " and " << std::min(Ei, m_Emax) 
-    << ", E=" << E
-    << journal::endl;
-#endif
 
   // final energy, wave vector
   double Ef = Ei - E;
@@ -122,26 +107,10 @@ mccomponents::kernels::SQEkernel::S
     Qmax = std::min(m_Qmax, ki+kf);
   if (Qmax<Qmin) return; // no scatter
   double Q = math::random(Qmin, Qmax);
-#ifdef DEBUG
-  m_details->debug 
-    << journal::at(__HERE__)
-    << "generate Q between " << Qmin << " and " << Qmax 
-    << ", Q=" << Q
-    << journal::endl;
-#endif
 
   // adjust probability of neutron event
   ev.probability *= m_sqe(Q,E) * Q * (Qmax-Qmin) * (Emax-Emin) / (2*ki*ki);
-#ifdef DEBUG
-  m_details->debug 
-    << journal::at(__HERE__)
-    << Q << ", " << E << ", "
-    << Qmin << ", " << Qmax << ", "
-    << Emin << ", " << Emax << ", "
-    << ki << ", "
-    << m_sqe(Q,E)
-    << journal::endl;
-#endif
+
   // figure out the direction of the out-going neutron
   double cost = (kf*kf + ki*ki - Q*Q)/2/kf/ki;
 
@@ -168,15 +137,6 @@ mccomponents::kernels::SQEkernel::S
   
   V3d ekf = e1*cost + e2*sint*cosp + e3 *sint*sinp;
   
-#ifdef DEBUG
-  m_details->debug 
-    << journal::at(__HERE__)
-    << "e1 = " << e1 << journal::newline
-    << "e2 = " << e2 << journal::newline
-    << "e3 = " << e3 << journal::newline
-    << "ekf = " << ekf << journal::newline
-    << journal::endl;
-#endif
   ev.state.velocity = ekf * (kf*conversion::k2v);
 }
 

--- a/packages/mccomponents/lib/kernels/sample/SQkernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/SQkernel.cc
@@ -19,24 +19,6 @@
 #include "mccomponents/math/random.h"
 #include "mccomponents/physics/constants.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
-struct mccomponents::kernels::SQkernel::Details {
-
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
-};
-
-
-#ifdef DEBUG
-const char mccomponents::kernels::SQkernel::Details::jrnltag[] = "SQkernel";
-#endif
 
 
 mccomponents::kernels::SQkernel::SQkernel
@@ -48,8 +30,7 @@ mccomponents::kernels::SQkernel::SQkernel
     m_scattering_coefficient( scattering_coefficient ),
     m_epsilon(1.e-10),
     m_Qmin(Qmin), m_Qmax(Qmax), m_DQ(Qmax-Qmin),
-    m_sq(sq),
-    m_details( new Details )
+    m_sq(sq)
 {}
 
 
@@ -101,13 +82,6 @@ mccomponents::kernels::SQkernel::S
     Qmax = std::min(m_Qmax, ki+kf);
   if (Qmax<Qmin) return; // no scatter
   double Q = math::random(Qmin, Qmax);
-#ifdef DEBUG
-  m_details->debug 
-    << journal::at(__HERE__)
-    << "generate Q between " << Qmin << " and " << Qmax 
-    << ", Q=" << Q
-    << journal::endl;
-#endif
 
   // adjust probability of neutron event
   // !!!!!!!!!
@@ -140,15 +114,6 @@ mccomponents::kernels::SQkernel::S
 
   V3d ekf = e1*cost + e2*sint*cosp + e3 *sint*sinp;
   
-#ifdef DEBUG
-  m_details->debug 
-    << journal::at(__HERE__)
-    << "e1 = " << e1 << journal::newline
-    << "e2 = " << e2 << journal::newline
-    << "e3 = " << e3 << journal::newline
-    << "ekf = " << ekf << journal::newline
-    << journal::endl;
-#endif
   ev.state.velocity = ekf * (kf*conversion::k2v);
 }
 

--- a/packages/mccomponents/lib/kernels/sample/SvQkernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/SvQkernel.cc
@@ -11,24 +11,8 @@
 #include "mccomponents/math/random.h"
 #include "mccomponents/physics/constants.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
-struct mccomponents::kernels::SvQkernel::Details {
-
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-  Details() : debug( jrnltag ) {}
-#endif
-};
-
-
-#ifdef DEBUG
-const char mccomponents::kernels::SvQkernel::Details::jrnltag[] = "SvQkernel";
-#endif
 
 mccomponents::kernels::SvQkernel::SvQkernel
 ( double absorption_coefficient,
@@ -37,8 +21,7 @@ mccomponents::kernels::SvQkernel::SvQkernel
   : m_absorption_coefficient( absorption_coefficient ),
     m_scattering_coefficient( scattering_coefficient ),
     m_epsilon(1.e-10),
-    m_sq(sq),
-    m_details( new Details )
+    m_sq(sq)
 {}
 
 double

--- a/packages/mccomponents/lib/kernels/sample/diffraction/EPSCDiffractionKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/diffraction/EPSCDiffractionKernel.cc
@@ -22,15 +22,6 @@
 #include "mccomponents/math/random.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-#ifdef DEBUG
-// Example of debugging
-m_details->debug  << "theta: " << theta << journal::endl;
-#endif
-
 
 struct mccomponents::kernels::EPSCDiffractionKernel::Details {
   double absorption_cross_section;
@@ -185,10 +176,6 @@ void
 mccomponents::kernels::EPSCDiffractionKernel::S
 ( mcni::Neutron::Event & ev )
 {
-#ifdef DEBUG
-  m_details->debug << "in" << ev << journal::endl;
-#endif
-
   // input neutron state
   mcni::Neutron::State & state = ev.state;
   // incident neutron velocity
@@ -210,13 +197,6 @@ mccomponents::kernels::EPSCDiffractionKernel::S
   typedef mcni::Vector3<double> V3d;
   V3d vf(vx,vy,vz);
   state.velocity = vf;
-
-#ifdef DEBUG
-  m_details->debug
-    << "out" << ev
-    << journal::endl;
-#endif
-
 }
 
 

--- a/packages/mccomponents/lib/kernels/sample/diffraction/SimplePowderDiffractionKernel.cc
+++ b/packages/mccomponents/lib/kernels/sample/diffraction/SimplePowderDiffractionKernel.cc
@@ -16,9 +16,6 @@
 #include "mcni/neutron/units_conversion.h"
 #include "mccomponents/math/random.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 using namespace std;
 
@@ -27,12 +24,6 @@ struct mccomponents::kernels::SimplePowderDiffractionKernel::Details {
 
   // types
   typedef SimplePowderDiffractionKernel kernel_t;
-
-  // data
-#ifdef DEBUG
-  const static char jrnltag[];
-  journal::debug_t debug;
-#endif
 
   kernel_t *kernel;
   
@@ -60,16 +51,10 @@ struct mccomponents::kernels::SimplePowderDiffractionKernel::Details {
 };
 
 
-#ifdef DEBUG
-const char mccomponents::kernels::SimplePowderDiffractionKernel::Details::jrnltag[] = "SimplePowderDiffractionKernel";
-#endif
 
 mccomponents::kernels::SimplePowderDiffractionKernel::Details::Details
 (const SimplePowderDiffractionData & data, kernel_t * i_kernel)
   :
-#ifdef DEBUG
-  debug( jrnltag ),
-#endif
   kernel(i_kernel),
   pack(1.),
   // XsectionFactor = 1, if cross-section in fm^2, or XsectionFactor = 100, if cross-section in barns
@@ -86,9 +71,6 @@ mccomponents::kernels::SimplePowderDiffractionKernel::Details::Details
   my_s_v2 = new double[Npeaks];
   
   unitcell_volume = data.unitcell_volume;
-#ifdef DEBUG
-  debug << "unitcell_volume: " << unitcell_volume << journal::endl;
-#endif
   
   for(int i=0; i<Npeaks; i++)
     {
@@ -107,11 +89,6 @@ mccomponents::kernels::SimplePowderDiffractionKernel::Details::Details
 
       // make sure the list is sorted
       if (i>0) assert(q_v[i-1] <= q_v[i]);
-#ifdef DEBUG
-      debug << i << ": my_s_v2, q_v, w_v=" 
-	    << my_s_v2[i] << ", " << q_v[i] << ", " << w_v[i]
-	    << journal::endl;
-#endif
     }
   
   //coherent_cross_section = scattering_coefficient(const mcni::Neutron::Event& ev );
@@ -178,9 +155,6 @@ mccomponents::kernels::SimplePowderDiffractionKernel::absorption_coefficient(con
   const mcni::Neutron::State &state = ev.state;
   double v_l = state.velocity.length();
   double ret = m_details->absorption_coeff*2200/v_l;  //inversely proportional to velocity
-#ifdef DEBUG
-  m_details->debug << "absorption_coeff: " << ret << journal::endl;
-#endif
   return ret;
 }
 
@@ -191,12 +165,6 @@ mccomponents::kernels::SimplePowderDiffractionKernel::scattering_coefficient(con
   double xs = m_details->scattering_xs(ev),
     v0 = m_details->unitcell_volume,
     ret = xs/v0;
-#ifdef DEBUG
-  m_details->debug
-    << "xs=" << xs << "v0=" << v0 
-    << "scattering_coefficient:" << ret 
-    << journal::endl;
-#endif
   return ret;
 }
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/AbstractDOS.h
+++ b/packages/mccomponents/lib/kernels/sample/phonon/AbstractDOS.h
@@ -14,9 +14,6 @@
 #define DANSE_PHONON_ABSTRACTDOS_H
 
 
-#include "journal/debug.h"
-#include "journal/warning.h"
-
 
 namespace DANSE{ namespace phonon {
 
@@ -56,12 +53,6 @@ namespace DANSE{ namespace phonon {
     // 
     FLT operator () ( const FLT & e ) const {
       if (e<m_emin or e> m_emax) {
-#ifdef DEBUG
-	journal::debug_t debug("phonon::DOS");
-	debug << journal::at(__HERE__)
-	      << FLT(e) << " is out of range: (" << m_emin
-	      << ", " << m_emax << ")" << journal::endl;
-#endif 
 	return 0.0;
       }
       return value( e );

--- a/packages/mccomponents/lib/kernels/sample/phonon/CoherentInelastic_PolyXtal.cc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/CoherentInelastic_PolyXtal.cc
@@ -13,7 +13,6 @@
 
 
 #include <cassert>
-#include "journal/warning.h"
 
 
 // XXX
@@ -26,10 +25,6 @@
 
 #ifdef DEBUG
 #define __DEBUG__PHNN__COHINEL_POLY__
-#endif
-
-#ifdef __DEBUG__PHNN__COHINEL_POLY__
-#include "journal/debug.h"
 #endif
 
 #include "mccomponents/physics/constants.h"
@@ -108,12 +103,6 @@ const
   namespace conversion = mcni::neutron_units_conversion;
 
   float_t v_i_l = v_i.length();
-#ifdef DEEPDEBUG
-  journal::debug_t debug(jrnltag);
-  debug << journal::at(__HERE__)
-	<< "vi length = " << v_i_l
-	<< journal::endl;
-#endif
 
   // == theta ==
   float_t cos_theta = (v_i_l*v_i_l+v_f_l*v_f_l - v_Q_l*v_Q_l)
@@ -194,17 +183,6 @@ Details::pick_a_valid_Q_vector
     v_f_l = conversion::E2v(E_f);
 
     // debug
-#ifdef DEEPDEBUG
-    journal::debug_t debug(jrnltag);
-    //    std::cout << "In file " << __FILE__ << " line " << __LINE__ << "; "
-    debug << journal::at(__HERE__)
-	  << "Q = " << Q << "; "
-	  << "v_Q_l = " << v_Q_l << "; "
-	  << "omega = " << omega << "; "
-	  << "E_f = " << E_f << "; "
-	  << "v_f_l = " << v_f_l << "; "
-	  << journal::endl; 
-#endif 
     //}
     // == make sure the Q is good ==
   } while ( v_Q_l<std::abs(v_i_l-v_f_l) || v_Q_l>v_i_l+v_f_l );
@@ -228,16 +206,6 @@ Details::pick_Ef
   } else {
     Ef = Ei + omega;
   }
-  // debug
-#ifdef DEEPDEBUG
-  journal::debug_t debug(jrnltag);
-  //    std::cout << "In file " << __FILE__ << " line " << __LINE__ << "; "
-  debug << journal::at(__HERE__)
-	<< "Ei = " << Ei << "; "
-	<< "Ef = " << Ef << "; "
-	<< journal::endl; 
-#endif 
-  
   return Ef;
 }
   
@@ -280,20 +248,6 @@ CoherentInelastic_PolyXtal
 {
   
   assert ( atoms.size() == disp.nAtoms() );
-#ifdef DEBUG
-  journal::debug_t debug(m_details->jrnltag);
-  debug << "m_disp=" << &m_disp << journal::newline;
-  
-  debug << "m_atoms=";
-  for (size_t i = 0; i< m_atoms.size(); i++)
-    debug  << m_atoms[i] << journal::newline;
-
-  debug << "m_DW_calc=" << m_DW_calc << journal::newline;
-  debug << "m_Temperature=" << m_Temperature << journal::newline
-	<< "m_uc_vol=" << m_uc_vol << journal::newline;
-  debug << journal::endl;
-  
-#endif
   
   // unit cell vol
   m_uc_vol = a|(b*c);
@@ -304,9 +258,6 @@ CoherentInelastic_PolyXtal
   for (size_t i=0; i<m_atoms.size(); i++) {
     m_total_scattering_xs += m_atoms[i].coherent_cross_section;
   }
-#ifdef DEBUG
-  debug << "m_total_scattering_xs:" << m_total_scattering_xs << journal::newline;
-#endif
   
   m_total_absorption_xs = 0;
   for (size_t i=0; i<m_atoms.size(); i++) {
@@ -349,10 +300,6 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
 {
   namespace conversion = mcni::neutron_units_conversion;
 
-#ifdef __DEBUG__PHNN__COHINEL_POLY__
-  journal::debug_t debug(m_details->jrnltag);
-#endif
-
   const mcni::Neutron::State  &ns  = ev.state;
   const V_t &v_i   = ns.velocity;
   
@@ -363,12 +310,6 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
   float_t v_i_l = v_i.length();
   // initial energy
   float_t E_i = conversion::v2E( v_i_l );
-
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "E_i =" << E_i << ","
-	<< journal::endl;
-#endif
 
   // pick branch
   unsigned int branch = pick_phonon_branch( m_disp.nBranches());
@@ -382,25 +323,12 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
     ( Q, v_Q_l, E_f, v_f_l, E_i, v_i_l, branch);
   float_t  omega = E_i - E_f;
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "omega =" << omega << ","
-	<< "Q =" << Q << ","
-	<< journal::endl;
-#endif
-
 
   // = rotate the Q vector so that the energy relation is satistied =
   // = actually this is done by directly determine the direction of =
   // = final velocity of neutron =
   V_t v_f;
   m_details->pick_v_f( prob, v_f, v_i, v_f_l, v_Q_l);
-
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "vf =" << v_f
-	<< journal::endl;
-#endif
 
 
   // change the velocity of neutron. other things stay put
@@ -413,46 +341,18 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
   float_t k_i_l = v2k * v_i_l;
   float_t k_f_l = v2k * v_f_l;
   float_t Q_l = v2k * v_Q_l;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "ki length = " << k_i_l << ", "
-	<< "kf length = " << k_f_l << ", "
-	<< "Q length = " << Q_l
-	<< journal::endl;
-#endif
 
   // thermal factor
   float_t therm_factor = phonon_bose_factor( omega, m_Temperature );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "omega = " << omega << ", "
-	<< "thermal factor = " << therm_factor << ", "
-	<< journal::endl;
-#endif
 
   // debye waller factor 
   float_t DW = m_DW_calc->DW( Q_l );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "debye waller factor = " << DW
-	<< journal::endl;
-#endif
   DW = std::exp( -DW );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "debye waller factor = " << DW
-	<< journal::endl;
-#endif
 
   if (E_i > omega) prob *= 2.0; // two choices of E_f: E_f>E_i or E_f<E_i
 
   // uc vol should be in scattering_coefficient, not here
   // prob /= m_uc_vol;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   // prob *= m_sigma_coh/m_Mass; //should be \sum{sigma_inc/M}
   //
   // This term is the term of |\sum\frac{b_d}{M_d} exp(i\kappa\dot d) (\kappa \dot e) |^2 of page 46 of Squires.
@@ -476,58 +376,15 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
   // will cancel with meV unit of phonon energy
   prob *= conversion::ksquare2E(norm_of_slsum);
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob /= std::abs(omega);
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   
   prob *= DW;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= k_f_l/k_i_l;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= therm_factor;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= 1/(k_i_l)/(k_f_l)/(Q_l);
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= m_details->calc_AccessibleReciVol(E_i); // reciprocal volume
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob /= 8*physics::pi;
   
-#ifdef DEEPDEBUG
-  debug << journal::endl;
-#endif
   //prob *= (epsdotq2*K2V*K2V*VS2E)/std::abs(omega)*therm_factor;
 }
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/CoherentInelastic_PolyXtal.cc.original-without-importance-sampling
+++ b/packages/mccomponents/lib/kernels/sample/phonon/CoherentInelastic_PolyXtal.cc.original-without-importance-sampling
@@ -14,7 +14,6 @@
 
 //#include <portinfo>
 #include <cassert>
-#include "journal/warning.h"
 
 
 // XXX
@@ -29,9 +28,6 @@
 #define __DEBUG__PHNN__COHINEL_POLY__
 #endif
 
-#ifdef __DEBUG__PHNN__COHINEL_POLY__
-#include "journal/debug.h"
-#endif
 
 #include "mccomponents/physics/constants.h"
 #include "mccomponents/kernels/sample/phonon/CoherentInelastic_PolyXtal.h"
@@ -108,12 +104,6 @@ const
   namespace conversion = mcni::neutron_units_conversion;
 
   float_t v_i_l = v_i.length();
-#ifdef DEEPDEBUG
-  journal::debug_t debug(jrnltag);
-  debug << journal::at(__HERE__)
-	<< "vi length = " << v_i_l
-	<< journal::endl;
-#endif
 
   // == theta ==
   float_t cos_theta = (v_i_l*v_i_l+v_f_l*v_f_l - v_Q_l*v_Q_l)
@@ -178,18 +168,6 @@ Details::pick_a_valid_Q_vector
 
     v_f_l = conversion::E2v(E_f);
 
-    // debug
-#ifdef DEEPDEBUG
-    journal::debug_t debug(jrnltag);
-    //    std::cout << "In file " << __FILE__ << " line " << __LINE__ << "; "
-    debug << journal::at(__HERE__)
-	  << "Q = " << Q << "; "
-	  << "v_Q_l = " << v_Q_l << "; "
-	  << "omega = " << omega << "; "
-	  << "E_f = " << E_f << "; "
-	  << "v_f_l = " << v_f_l << "; "
-	  << journal::endl; 
-#endif 
     //}
     // == make sure the Q is good ==
   } while ( v_Q_l<std::abs(v_i_l-v_f_l) || v_Q_l>v_i_l+v_f_l );
@@ -213,15 +191,6 @@ Details::pick_Ef
   } else {
     Ef = Ei + omega;
   }
-  // debug
-#ifdef DEEPDEBUG
-  journal::debug_t debug(jrnltag);
-  //    std::cout << "In file " << __FILE__ << " line " << __LINE__ << "; "
-  debug << journal::at(__HERE__)
-	<< "Ei = " << Ei << "; "
-	<< "Ef = " << Ef << "; "
-	<< journal::endl; 
-#endif 
   
   return Ef;
 }
@@ -235,10 +204,6 @@ Details::calc_relAccessibleReciVol_MC
  float_t Qcutoff, float_t E_i) const
 {
   if (numMCsteps<1000) {
-    journal::warning_t warning(jrnltag);
-    warning << journal::at(__HERE__)
-	    << "*** Number of MC steps must be larger than 1000 to obtain reliable results!" 
-	    << journal::endl;
     //throw;
   }
     
@@ -272,17 +237,6 @@ Details::calc_relAccessibleReciVol_MC
     
     v_f_l = conversion::E2v(E_f);
     
-    // debug
-#ifdef DEEPDEBUG
-    journal::debug_t debug(jrnltag);
-    debug << journal::at(__HERE__)
-	  << "Q = " << Q << "; "
-	  << "v_Q_l = " << v_Q_l << "; "
-	  << "omega = " << omega << "; "
-	  << "E_f = " << E_f << "; "
-	  << "v_f_l = " << v_f_l << "; "
-	  << journal::endl; 
-#endif 
     // increment the cooresponding bins
     N[branch]++;
     
@@ -301,13 +255,6 @@ Details::calc_relAccessibleReciVol_MC
   for (size_t br = 0; br<n_brs; br++) {
     res[br] = 1.0*valid_N[br]/N[br];
     
-#ifdef DEEPDEBUG
-    journal::debug_t debug(jrnltag);
-    debug << journal::at(__HERE__)
-	  << "phonon branch " << br
-	  << "ratio = " << res[br] 
-	  << journal::endl; 
-#endif 
   }
   return res;
 }
@@ -339,29 +286,12 @@ CoherentInelastic_PolyXtal
 {
   
   assert ( atoms.size() == disp.nAtoms() );
-#ifdef DEBUG
-  journal::debug_t debug(m_details->jrnltag);
-  debug << "m_disp=" << &m_disp << journal::newline;
-  
-  debug << "m_atoms=";
-  for (size_t i = 0; i< m_atoms.size(); i++)
-    debug  << m_atoms[i] << journal::newline;
-
-  debug << "m_DW_calc=" << m_DW_calc << journal::newline;
-  debug << "m_Temperature=" << m_Temperature << journal::newline
-	<< "m_uc_vol=" << m_uc_vol << journal::newline;
-  debug << journal::endl;
-  
-#endif
 
   // calculate the total scattering cross section
   m_total_scattering_xs = 0;
   for (size_t i=0; i<m_atoms.size(); i++) {
     m_total_scattering_xs += m_atoms[i].coherent_cross_section;
   }
-#ifdef DEBUG
-  debug << "m_total_scattering_xs:" << m_total_scattering_xs << journal::newline;
-#endif
   
   m_total_absorption_xs = 0;
   for (size_t i=0; i<m_atoms.size(); i++) {
@@ -378,11 +308,6 @@ CoherentInelastic_PolyXtal
     m_details->calc_relAccessibleReciVol_MC
     ( m_nMCsteps_to_calc_RARV, m_disp, m_Qcutoff, m_Ei);
 
-#ifdef DEBUG
-  for (int i=0; i<m_disp.nBranches(); i++)
-    debug << "m_relAccessibleReciVol_arr:" << m_relAccessibleReciVol_arr[i] << journal::newline;
-  debug << journal::endl;
-#endif
 
 }
 
@@ -421,9 +346,6 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
 {
   namespace conversion = mcni::neutron_units_conversion;
 
-#ifdef __DEBUG__PHNN__COHINEL_POLY__
-  journal::debug_t debug(m_details->jrnltag);
-#endif
 
   const mcni::Neutron::State  &ns  = ev.state;
   const V_t &v_i   = ns.velocity;
@@ -436,11 +358,6 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
   // initial energy
   float_t E_i = conversion::v2E( v_i_l );
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "E_i =" << E_i << ","
-	<< journal::endl;
-#endif
 
   // pick branch
   unsigned int branch = pick_phonon_branch( m_disp.nBranches());
@@ -454,25 +371,12 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
     ( Q, v_Q_l, E_f, v_f_l, m_Qcutoff, E_i, v_i_l, branch);
   float_t  omega = E_i - E_f;
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "omega =" << omega << ","
-	<< "Q =" << Q << ","
-	<< journal::endl;
-#endif
-
 
   // = rotate the Q vector so that the energy relation is satistied =
   // = actually this is done by directly determine the direction of =
   // = final velocity of neutron =
   V_t v_f;
   m_details->pick_v_f( prob, v_f, v_i, v_f_l, v_Q_l);
-
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "vf =" << v_f
-	<< journal::endl;
-#endif
 
 
   // change the velocity of neutron. other things stay put
@@ -485,46 +389,18 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
   float_t k_i_l = v2k * v_i_l;
   float_t k_f_l = v2k * v_f_l;
   float_t Q_l = v2k * v_Q_l;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "ki length = " << k_i_l << ", "
-	<< "kf length = " << k_f_l << ", "
-	<< "Q length = " << Q_l
-	<< journal::endl;
-#endif
 
   // thermal factor
   float_t therm_factor = phonon_bose_factor( omega, m_Temperature );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "omega = " << omega << ", "
-	<< "thermal factor = " << therm_factor << ", "
-	<< journal::endl;
-#endif
 
   // debye waller factor 
   float_t DW = m_DW_calc->DW( Q_l );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "debye waller factor = " << DW
-	<< journal::endl;
-#endif
   DW = std::exp( -DW );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "debye waller factor = " << DW
-	<< journal::endl;
-#endif
 
   if (E_i > omega) prob *= 2.0; // two choices of E_f: E_f>E_i or E_f<E_i
 
   // uc vol should be in scattering_coefficient, not here
   // prob /= m_uc_vol;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   // prob *= m_sigma_coh/m_Mass; //should be \sum{sigma_inc/M}
   //
   // This term is the term of |\sum\frac{b_d}{M_d} exp(i\kappa\dot d) (\kappa \dot e) |^2 of page 46 of Squires.
@@ -544,68 +420,19 @@ mccomponents::kernels::phonon::CoherentInelastic_PolyXtal::S
   // divide this quautity by \sigma_coh because we want a normalized
   // value. this quantity is similar to Q**2
   norm_of_slsum /= (m_total_scattering_xs*1e-28);
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "norm_of_slsum = " << norm_of_slsum << ", "
-	<< "ksquare2E(norm_of_slsum) = " << conversion::ksquare2E(norm_of_slsum * norm_of_slsum )
-	<< journal::endl;
-#endif
   // convert the q**2 in that term to be in energy unit (meV), which
   // will cancel with meV unit of phonon energy
   prob *= conversion::ksquare2E( norm_of_slsum*norm_of_slsum);
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   
   prob *= DW;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= k_f_l/k_i_l;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= therm_factor;
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob /= std::abs(omega);
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= 1/(k_i_l)/(k_f_l)/(Q_l);
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= m_Qcutoff * m_Qcutoff * m_Qcutoff * 8.0; // this is the size of the reciprocal space in which Q points are picked
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob *= m_relAccessibleReciVol_arr[branch];
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "prob = " << prob 
-	<< journal::endl;
-#endif
   prob /= 8*physics::pi;
-#ifdef DEEPDEBUG
-  debug << journal::endl;
-#endif
   //prob *= (epsdotq2*K2V*K2V*VS2E)/std::abs(omega)*therm_factor;
 }
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/CoherentInelastic_SingleXtal.cc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/CoherentInelastic_SingleXtal.cc
@@ -21,9 +21,6 @@
 #define DEBUG
 #endif
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 #include "mccomponents/kernels/sample/phonon/scattering_length.h"
 #include "mcni/exceptions.h"
@@ -119,14 +116,6 @@ mccomponents::kernels::phonon::CoherentInelastic_SingleXtal::CoherentInelastic_S
     m_target_region( &target_region),
     m_DV( deltaV_Jacobi )
 {
-#ifdef DEBUG
-  journal::debug_t debug(phonon_cohinel_sc_journal_channel);
-  debug << "m_disp=" << &m_disp << ","
-	<< "m_DW_calc=" << m_DW_calc << ","
-	<< "m_Temperature=" << m_Temperature << ","
-	<< "m_uc_vol=" << m_uc_vol << ","
-	<< journal::endl;
-#endif
   
   // calculate the total scattering cross section  
   m_tot_scattering_xs = 0;
@@ -158,37 +147,16 @@ const
   /// v_i..........neutron initial velocity
   /// v_i_l........magnitude of neutron initial velocity
 {
-#ifdef DEBUG
-  journal::debug_t debug(phonon_cohinel_sc_journal_channel);
-  debug << journal::at(__HERE__)
-	<< "entering pick_v_f" 
-	<< journal::endl;
-#endif
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "create function omega(q)-dE" 
-	<< journal::endl;
-#endif
   // function omega(Q)-dE
   Omega_q_minus_deltaE omq_m_dE(branch, v_f, v_i, v_i_l, m_disp);
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "find roots of function omega(Q)-dE" 
-	<< journal::endl;
-#endif
   // find roots of function omega(Q)-dE
   std::vector<float_t> vf_list;
   // number of roots
   vf_list = m_roots_finder.solve( 0, v_i_l*2, omq_m_dE );
   size_t nf = vf_list.size(); 
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "found " << nf << "roots." 
-	<< journal::endl;
-#endif
 
   if (nf<1) {
     std::cerr << "** Unable to find solution for function omega(Q)-dE";
@@ -202,41 +170,19 @@ const
         "Unable to find solution for function omega(Q)-dE");
     */
   }
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "choose a root from the roots" 
-	<< journal::endl;
-#endif
   // choose a root (length of vf)
   size_t index=mccomponents::math::random(size_t(0), nf);
   float_t v_f_l = vf_list[index];
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "chose root #" << index
-	<< ": " << v_f_l
-	<< journal::endl;
-#endif
   // adjust v_f
   v_f.normalize(); v_f = v_f * v_f_l;
   // adjust prob
   prob_factors.push_back(nf);
 
   // calculate Jacobi factor
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "calculate Jacobi factor near " << v_f_l
-	<< journal::endl;
-#endif
   float_t f1, f2;
   float_t delta_v = m_DV*v_i_l; // m_DV is fractional change
   f1 = omq_m_dE.evaluate( v_f_l-delta_v );
   f2 = omq_m_dE.evaluate( v_f_l+delta_v );
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "f1=" << f1
-	<< ", f2=" << f2
-	<< journal::endl;
-#endif
   using namespace mcni::neutron_units_conversion;
   // adjust prob
   // float_t Jacobi = std::abs(f2-f1)/(2*delta_v*k2v);
@@ -245,11 +191,6 @@ const
   using mcni::neutron_units_conversion::vsq2e;
   prob_factors.push_back(2*vsq2e*v_f_l/Jacobi);
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "probability factors" << prob_factors
-	<< journal::endl;
-#endif
   return false;
 }
 
@@ -258,9 +199,6 @@ void
 mccomponents::kernels::phonon::CoherentInelastic_SingleXtal::pick_a_final_state
 ( neutron_t & ev ) const
 {
-#ifdef DEBUG
-  journal::debug_t debug(phonon_cohinel_sc_journal_channel);
-#endif
   
   // init an array of probability factors which could result from various random-selection processes. 
   std::vector<float_t> prob_factors;
@@ -272,20 +210,12 @@ mccomponents::kernels::phonon::CoherentInelastic_SingleXtal::pick_a_final_state
   const neutron_t::state_t    &ns  = ev.state;
   V_t   v_i = ns.velocity;
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__) << "v_i = " << v_i << journal::endl;
-#endif
   
   /* initial velocity magnitude */
   float_t v_i_l = v_i.length();
   // initial energy
   float_t E_i = neutron_units_conversion::v2E( v_i_l );
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "E_i =" << E_i << ","
-	<< journal::endl;
-#endif
 
   // establish "good" branches (not too higher than Ei)
 #ifdef DEEPDEBUG
@@ -328,9 +258,6 @@ mccomponents::kernels::phonon::CoherentInelastic_SingleXtal::pick_a_final_state
   }
   prob_factors.push_back(solid_angle);
   prob_factors.push_back( good_branches.size() );
-#ifdef DEEPDEBUG
-    debug << journal::at(__HERE__) << "v_i = " << v_i << journal::endl;
-#endif
   
   float_t v_f_l = v_f.length();
   float_t E_f = neutron_units_conversion::v2E( v_f_l );  
@@ -338,12 +265,6 @@ mccomponents::kernels::phonon::CoherentInelastic_SingleXtal::pick_a_final_state
   // phonon energy
   float_t  omega = E_i - E_f;
   
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "omega =" << omega << ","
-	<< "E_f =" << E_f << ","
-	<< journal::endl;
-#endif
   // Q vector
   K_t Q = neutron_units_conversion::v2k*(v_i-v_f);
 
@@ -388,21 +309,6 @@ mccomponents::kernels::phonon::CoherentInelastic_SingleXtal::pick_a_final_state
   float_t prob_factor = mccomponents::math::product<float_t>( prob_factors );
   // we need to manipulate the neutron probability. get the reference here.
   float_t               &prob = ev.probability; 
-#ifdef DEEPDEBUG
-  if (prob_factor>100000) {
-    debug << journal::at(__HERE__)
-	  << "prob = " << prob << "\n"
-	  << "Q = " << Q << "\n"
-	  << "omega = " << omega << "\n"
-	  << "k_i = " << v_i* neutron_units_conversion::v2k << "\n"
-	  << "k_f = " << v_f* neutron_units_conversion::v2k << 
-      journal::endl;
-    for (int i=0; i<prob_factors.size(); i++) {
-      debug << " p[" << i << "] = " << prob_factors[i] << "\n";
-    }
-    debug << journal::endl;
-  }
-#endif
   prob *= prob_factor;
 }
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/DWFromDOS.icc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/DWFromDOS.icc
@@ -16,9 +16,6 @@
 #else
 
 
-#include "journal/warning.h"
-#include "journal/debug.h"
-#include "journal/info.h"
 #include <iomanip>
 
 #include "mccomponents/physics/constants.h"
@@ -32,12 +29,6 @@ void DANSE::phonon::DWFromDOS<FloatType>::calc_DW_core
 
   using namespace mccomponents;
 
-
-#ifdef DEBUG
-  journal::info_t info_DW("debye-waller");
-  journal::debug_t debug_DW("debye-waller");
-  journal::warning_t warning_DW("debye-waller");
-#endif
   m_core = 0.;
   float_t norm_fac=0.;
 
@@ -66,15 +57,6 @@ void DANSE::phonon::DWFromDOS<FloatType>::calc_DW_core
       frac = 0.5;
     m_core += f[i] * frac;
     norm_fac += Z * frac;
-#ifdef DEBUG
-    debug_DW  << journal::at(__HERE__)
-	      << "w=" <<w << ","
-	      << "Z=" <<Z << ","
-	      << "BE="<<BoseEinsteinDistribution(w, T_in_Kelvin) << ","
-	      << "core=" <<m_core << ","
-	      << "norm_fac=" <<norm_fac << ","
-	      << journal::endl;
-#endif
     // std::cout << f[i] << std::endl;
   }
   // compute the contribution at w=0, by interpolating
@@ -98,24 +80,11 @@ void DANSE::phonon::DWFromDOS<FloatType>::calc_DW_core
   // m_core /= norm_fac; // now core = \int Z(w)*(2<n>+1)/(hbar*w) dw
   m_core *= dw;
   
-#ifdef DEBUG
-  debug_DW  << journal::at(__HERE__)
-	    << m_core << journal::endl;
-#endif
   using physics::hbar; using physics::atomic_mass;
   m_core *= hbar*hbar/2/atomic_mass/atom_mass;
   // now core = hbar^2/2M*integration
   
   m_core *= 1e20; // so that Q can be given in the unit A^-1
-  
-#ifdef DEBUG
-  debug_DW  << journal::at(__HERE__)
-	    << "hbar=" << hbar << ","
-	    << "atomic_mass=" <<atomic_mass << ","
-	    << "atom_mass="<<atom_mass << ","
-	    << "core=" <<m_core 
-	    << journal::endl;
-#endif
 }
 
 template <typename FloatType>

--- a/packages/mccomponents/lib/kernels/sample/phonon/IncoherentInelastic.cc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/IncoherentInelastic.cc
@@ -14,7 +14,6 @@
 
 //#include <portinfo>
 #include <cassert>
-#include "journal/warning.h"
 
 
 // #define DEEPDEBUG
@@ -28,9 +27,6 @@
 #define __DEBUG__PHNN__COHINEL_POLY__
 #endif
 
-#ifdef __DEBUG__PHNN__COHINEL_POLY__
-#include "journal/debug.h"
-#endif
 
 #include "mcni/math/func.h"
 #include "mccomponents/physics/constants.h"
@@ -120,14 +116,6 @@ Details::get_mass_and_xs
 (const atoms_t &atoms, float_t &mass, 
  float_t &scattering_xs, float_t &absorption_xs)
 {
-#ifdef DEBUG
-  journal::debug_t debug(jrnltag);
-  debug << "atoms=";
-  for (size_t i = 0; i< atoms.size(); i++)
-    debug  << atoms[i] << journal::newline;
-  debug << journal::endl;
-  
-#endif
   
   mass = 0;
   scattering_xs = 0;
@@ -207,9 +195,6 @@ mccomponents::kernels::phonon::IncoherentInelastic::S
 {
   namespace conversion = mcni::neutron_units_conversion;
 
-#ifdef DEEPDEBUG
-  journal::debug_t debug(m_details->jrnltag);
-#endif
 
   const mcni::Neutron::State  &ns  = ev.state;
   const V_t v_i   = ns.velocity;
@@ -225,11 +210,6 @@ mccomponents::kernels::phonon::IncoherentInelastic::S
   // = pick a scattering direction =
   V_t dir_f;
   math::choose_direction( dir_f ); dir_f.normalize();
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "picked scattering direction " << dir_f
-	<< journal::endl;
-#endif
 
 #ifdef DEEPDEBUG1
   //prob*=4pi;
@@ -240,11 +220,6 @@ mccomponents::kernels::phonon::IncoherentInelastic::S
   // = pick the final energy =
   float_t e_range;
   float_t E_f = m_details->pick_Ef( e_range, E_i, m_max_phonon_energy );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "picked final energy " << E_f
-	<< journal::endl;
-#endif
 
   // +/- phonon energy
   float_t  omega = E_i - E_f; 
@@ -265,19 +240,6 @@ mccomponents::kernels::phonon::IncoherentInelastic::S
   // length of Q
   float_t Q_l = Q.length();
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "* E_i=" << E_i << ","
-	<< "E_f=" << E_f << ","
-	<< "v_f_l=" << v_f_l << ","
-	<< "v_i=" << v_i << ","
-	<< "v_f=" << v_f << ","
-	<< "v_Q=" << v_Q << ","
-	<< "omega =" << omega << ","
-	<< "Q =" << Q << ","
-	<< "T =" << m_Temperature << ","
-	<< journal::endl;
-#endif
 
   // change the velocity of neutron. other things stay put
   ev.state.velocity = v_f;
@@ -288,11 +250,6 @@ mccomponents::kernels::phonon::IncoherentInelastic::S
 
   // debye waller factor	  
   float_t DW = exp( -m_DW_calc->DW( Q_l ) );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "debye waller factor " << DW
-	<< journal::endl;
-#endif
 
   prob *= e_range; // for picking Ef
 
@@ -332,19 +289,6 @@ mccomponents::kernels::phonon::IncoherentInelastic::S
       << std::endl;
     throw;
   }
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "* prob = " << prob << ","
-	<< "v_f_l/v_i_l=" << v_f_l/v_i_l << ","
-	<< "m_Mass=" << m_Mass << ","
-	<< "DW=" << DW << ","
-	<< "k2E(Q_l)/abs(omega)=" << conversion::k2E(Q_l)/std::abs(omega) << ","
-	<< "m_dos( abs(omega) )=" << (*m_dos)( std::abs(omega) ) << ","
-	<< "therm_factor=" << therm_factor << ","
-	<< "Q=" << Q_l << ", "
-	<< "omega=" << omega << ", "
-	<< journal::endl;
-#endif
 }
 
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/IncoherentInelastic_EnergyFocusing.cc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/IncoherentInelastic_EnergyFocusing.cc
@@ -5,7 +5,6 @@
 
 //#include <portinfo>
 #include <cassert>
-#include "journal/warning.h"
 
 
 // #define DEEPDEBUG
@@ -17,10 +16,6 @@
 
 #ifdef DEBUG
 #define __DEBUG__PHNN__COHINEL_POLY__
-#endif
-
-#ifdef __DEBUG__PHNN__COHINEL_POLY__
-#include "journal/debug.h"
 #endif
 
 #include "mcni/math/func.h"
@@ -113,15 +108,6 @@ Details::get_mass_and_xs
 (const atoms_t &atoms, float_t &mass, 
  float_t &scattering_xs, float_t &absorption_xs)
 {
-#ifdef DEBUG
-  journal::debug_t debug(jrnltag);
-  debug << "atoms=";
-  for (size_t i = 0; i< atoms.size(); i++)
-    debug  << atoms[i] << journal::newline;
-  debug << journal::endl;
-  
-#endif
-  
   mass = 0;
   scattering_xs = 0;
   absorption_xs = 0;
@@ -202,10 +188,6 @@ mccomponents::kernels::phonon::IncoherentInelastic_EnergyFocusing::S
 {
   namespace conversion = mcni::neutron_units_conversion;
 
-#ifdef DEEPDEBUG
-  journal::debug_t debug(m_details->jrnltag);
-#endif
-
   const mcni::Neutron::State  &ns  = ev.state;
   const V_t v_i   = ns.velocity;
   
@@ -220,11 +202,6 @@ mccomponents::kernels::phonon::IncoherentInelastic_EnergyFocusing::S
   // = pick a scattering direction =
   V_t dir_f;
   math::choose_direction( dir_f ); dir_f.normalize();
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "picked scattering direction " << dir_f
-	<< journal::endl;
-#endif
 
 #ifdef DEEPDEBUG1
   //prob*=4pi;
@@ -239,11 +216,6 @@ mccomponents::kernels::phonon::IncoherentInelastic_EnergyFocusing::S
   if (E_f < 0) {
     prob = -1.; return;
   }
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "picked final energy " << E_f
-	<< journal::endl;
-#endif
 
   // +/- phonon energy
   float_t  omega = E_i - E_f; 
@@ -264,20 +236,6 @@ mccomponents::kernels::phonon::IncoherentInelastic_EnergyFocusing::S
   // length of Q
   float_t Q_l = Q.length();
 
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "* E_i=" << E_i << ","
-	<< "E_f=" << E_f << ","
-	<< "v_f_l=" << v_f_l << ","
-	<< "v_i=" << v_i << ","
-	<< "v_f=" << v_f << ","
-	<< "v_Q=" << v_Q << ","
-	<< "omega =" << omega << ","
-	<< "Q =" << Q << ","
-	<< "T =" << m_Temperature << ","
-	<< journal::endl;
-#endif
-
   // change the velocity of neutron. other things stay put
   ev.state.velocity = v_f;
 
@@ -287,11 +245,6 @@ mccomponents::kernels::phonon::IncoherentInelastic_EnergyFocusing::S
 
   // debye waller factor	  
   float_t DW = exp( -m_DW_calc->DW( Q_l ) );
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "debye waller factor " << DW
-	<< journal::endl;
-#endif
 
   prob *= e_range; // for picking Ef
 
@@ -331,19 +284,6 @@ mccomponents::kernels::phonon::IncoherentInelastic_EnergyFocusing::S
       << std::endl;
     throw;
   }
-#ifdef DEEPDEBUG
-  debug << journal::at(__HERE__)
-	<< "* prob = " << prob << ","
-	<< "v_f_l/v_i_l=" << v_f_l/v_i_l << ","
-	<< "m_Mass=" << m_Mass << ","
-	<< "DW=" << DW << ","
-	<< "k2E(Q_l)/abs(omega)=" << conversion::k2E(Q_l)/std::abs(omega) << ","
-	<< "m_dos( abs(omega) )=" << (*m_dos)( std::abs(omega) ) << ","
-	<< "therm_factor=" << therm_factor << ","
-	<< "Q=" << Q_l << ", "
-	<< "omega=" << omega << ", "
-	<< journal::endl;
-#endif
 }
 
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/LinearlyInterpolatedDOS.icc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/LinearlyInterpolatedDOS.icc
@@ -29,8 +29,6 @@
 #include <numeric>
 #include <iostream>
 
-#include "journal/error.h"
-#include "journal/debug.h"
 
 
 #include "mccomponents/kernels/sample/phonon/LinearlyInterpolatedGridData_1D.h"
@@ -64,39 +62,20 @@ DANSE::phonon::LinearlyInterpolatedDOS<FloatType, Array_1D>::LinearlyInterpolate
     m_e0(e0), m_de(de), m_n(ne), m_e1( base_t::emax() )
 {
   if  ( ne != Z.size() ) {
-    
-    journal::error_t err("DOS");
-    err << journal::at(__HERE__)
-        << "***energy axis and dos axis have differnet size of data" << journal::newline
-	<< "ne = " << ne << journal::newline
-        << "Z.size = " << Z.size() << journal::newline
-	<< journal::endl;
-    
     throw DOS_Init_Error();
   }
 
   if  ( ne < 2 ) {
-    
-    journal::error_t err("DOS");
-    err << "***dos curve must have at least two data points!"
-	<< journal::endl;
-    
     throw DOS_Init_Error();
   }
 
   // make sure e is ascending
   if (de<0) {
-    journal::error_t err("DOS");
-    err << "***the e axis of dos curve must be ascending!" 
-	<< journal::endl;
     throw DOS_Init_Error();
   }
 
   // make sure e[0] >= 0.0
   if ( e0 < 0.0 ) {
-    journal::error_t err("DOS");
-    err << "***the e axis of dos curve must be positive!" 
-	<< journal::endl;
     throw DOS_Init_Error();
   }
 
@@ -116,10 +95,6 @@ template <typename FloatType, typename Array_1D>
 DANSE::phonon::LinearlyInterpolatedDOS<FloatType, Array_1D>::~LinearlyInterpolatedDOS
 ()
 {
-#ifdef DEBUG
-  journal::debug_t debug("DOS");
-  debug << "DOS " << this << " destroyed" << journal::endl;
-#endif
 }
 
 

--- a/packages/mccomponents/lib/kernels/sample/phonon/Omega_minus_deltaE.cc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/Omega_minus_deltaE.cc
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <cmath>
 //#include <portinfo>
-#include "journal/debug.h"
 #include "mcni/neutron/units_conversion.h"
 #include "mccomponents/kernels/sample/phonon/vector3.h"
 #include "mccomponents/kernels/sample/phonon/AbstractDispersion_3D.h"
@@ -34,39 +33,18 @@ Omega_q_minus_deltaE::Omega_q_minus_deltaE
    _vf_direction(vf_dir), _vi(vi),
    _abs_vi(abs_vi), _disp(&disp) 
 {
-#ifdef DEBUG
-  journal::debug_t debug("Omega_minus_deltaE ctor");
-#endif
-
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "vf direction=" << vf_dir 
-	<< journal::endl;
-#endif
 }
 
 
 //! w(q)-abs(Ei-Ef)
 Omega_q_minus_deltaE::float_t mccomponents::kernels::phonon::Omega_q_minus_deltaE::evaluate( float_t vf ) const
 {
-#ifdef DEBUG
-  journal::debug_t debug(Omega_minus_deltaE_debug_channel);
-#endif
 
   const float_t &vv_x = _vf_direction.x, 
     &vv_y = _vf_direction.y, &vv_z = _vf_direction.z;
 
   const float_t &vi_x = _vi.x, &vi_y = _vi.y, &vi_z = _vi.z;
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "vi=" << vi_x << ", " << vi_y << ", " << vi_z
-	<< journal::newline
-	<< "vf_direction" << _vf_direction
-	<< journal::newline
-	<< "vf length" << vf
-	<< journal::endl;
-#endif
 
   float_t qx, qy, qz, res_phonon, res_neutron;  
   
@@ -76,11 +54,6 @@ Omega_q_minus_deltaE::float_t mccomponents::kernels::phonon::Omega_q_minus_delta
   qy=v2k*(vi_y-vf*vv_y);
   qz=v2k*(vi_z-vf*vv_z);
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "q=" << qx << ", " << qy << ", " << qz 
-	<< journal::endl;
-#endif
 
   res_phonon = _disp->energy(_branch, K_t(qx, qy, qz));
   // std::cout << "vf" << vf << std::endl;

--- a/packages/mccomponents/lib/kernels/sample/phonon/PeriodicDispersion_3D.cc
+++ b/packages/mccomponents/lib/kernels/sample/phonon/PeriodicDispersion_3D.cc
@@ -12,7 +12,6 @@
 
 
 #include <cmath>
-#include "journal/debug.h"
 #include "mccomponents/kernels/sample/phonon/PeriodicDispersion_3D.h"
 
 
@@ -34,16 +33,8 @@ Details{
   K_t reducedQ( const K_t & Q );
   const ReciprocalCell &rc;
   K_t a1, a2, a3;
-  
-#ifdef DEBUG
-  static const char *jrnltag;
-#endif
 };
 
-
-#ifdef DEBUG
-const char *DANSE::phonon::PeriodicDispersion_3D::Details::jrnltag = "periodicdispersion_3d";
-#endif
 
 // algorithm hint:
 // b1, b2, b3
@@ -61,13 +52,6 @@ Details( const w_t & target )
   mcni::get_inversions<float_t>
     ( rc.b1, rc.b2, rc.b3,
       a1, a2, a3 );
-#ifdef DEBUG 	
-  journal::debug_t debug(jrnltag);
-  debug << "b1,b2,b3=" << rc.b1 << ", " << rc.b2 << ", " << rc.b3 
-	<< journal::newline
-	<< "a1,a2,a3=" << a1 << ", " << a2 << ", " << a3 
-	<< journal::endl;
-#endif
 }
 
 DANSE::phonon::PeriodicDispersion_3D::
@@ -124,11 +108,6 @@ DANSE::phonon::PeriodicDispersion_3D::
 energy(n_t branch_id, const K_t &k) const
 {
   K_t q = m_details->reducedQ( k );
-#ifdef DEBUG
-  journal::debug_t debug(m_details->jrnltag);
-  debug << "k=" << k << journal::newline
-	<< "q=" << q << journal::endl;
-#endif
   return m_core.energy( branch_id, q );
 }
 

--- a/packages/mccomponents/lib/math/random.cc
+++ b/packages/mccomponents/lib/math/random.cc
@@ -14,9 +14,6 @@
 #include <cstdlib>
 #include "mccomponents/math/random.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
   

--- a/packages/mccomponents/lib/math/random/gaussian.cc
+++ b/packages/mccomponents/lib/math/random/gaussian.cc
@@ -20,9 +20,6 @@
 #define DEBUG
 #endif
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 double 

--- a/packages/mccomponents/lib/math/random/geometry.cc
+++ b/packages/mccomponents/lib/math/random/geometry.cc
@@ -25,9 +25,6 @@
 #define DEBUG
 #endif
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 double 

--- a/packages/mccomponents/lib/math/random/lorentzian.cc
+++ b/packages/mccomponents/lib/math/random/lorentzian.cc
@@ -12,9 +12,6 @@
 #define DEBUG
 #endif
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
 
 
 double

--- a/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testCompositeScatteringKernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testCompositeScatteringKernel.cc
@@ -16,11 +16,6 @@
 #include "mccomposite/mccomposite.h"
 #include "mccomponents/homogeneous_scatterer/CompositeScatteringKernel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 class Kernel1: public mccomponents::AbstractScatteringKernel {
 public:
   Kernel1( double mu, double sigma ) 
@@ -105,10 +100,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-  // journal::debug_t("CompositeNeutronScatterer_Impl").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testDGSSXResPixel.cc
+++ b/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testDGSSXResPixel.cc
@@ -6,11 +6,6 @@
 #include "mccomponents/homogeneous_scatterer/AbstractScatteringKernel.h"
 #include "mccomponents/homogeneous_scatterer/DGSSXResPixel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 
 // the absorber will absorb all neutrons
 void test1()
@@ -37,10 +32,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-  // journal::debug_t("CompositeNeutronScatterer_Impl").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testHollowScatterers.cc
+++ b/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testHollowScatterers.cc
@@ -15,10 +15,6 @@
 #include "mccomponents/homogeneous_scatterer/AbstractScatteringKernel.h"
 #include "mccomponents/homogeneous_scatterer/HomogeneousNeutronScatterer.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 // only scattering
 class ToX : public mccomponents::AbstractScatteringKernel {

--- a/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testHomogeneousNeutronScatterer.cc
+++ b/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testHomogeneousNeutronScatterer.cc
@@ -16,10 +16,6 @@
 #include "mccomponents/homogeneous_scatterer/AbstractScatteringKernel.h"
 #include "mccomponents/homogeneous_scatterer/HomogeneousNeutronScatterer.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 
 class Absorber : public mccomponents::AbstractScatteringKernel {
@@ -362,10 +358,6 @@ void test7()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-  // journal::debug_t("CompositeNeutronScatterer_Impl").activate();
-#endif
   test1();
   test2();
   test3();

--- a/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testMultipleScattering.cc
+++ b/packages/mccomponents/tests/libmccomponents/homogeneous_scatterer/testMultipleScattering.cc
@@ -17,10 +17,6 @@
 #include "mccomponents/homogeneous_scatterer/AbstractScatteringKernel.h"
 #include "mccomponents/homogeneous_scatterer/HomogeneousNeutronScatterer.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 
 class Absorber : public mccomponents::AbstractScatteringKernel {
@@ -103,10 +99,6 @@ void test6()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-  // journal::debug_t("CompositeNeutronScatterer_Impl").activate();
-#endif
   test6();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/detector/testEventModeMCA.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/detector/testEventModeMCA.cc
@@ -17,11 +17,6 @@
 #include "mccomponents/kernels/detector/EventModeMCA.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 void test1()
 {
   using namespace mccomponents;
@@ -104,9 +99,6 @@ void test2a()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   test1a();
   test2();

--- a/packages/mccomponents/tests/libmccomponents/kernels/detector/testHe3.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/detector/testHe3.cc
@@ -17,10 +17,6 @@
 #include "mccomponents/physics/constants.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 class He3: public mccomponents::kernels::He3 {
 public:
   He3( double p ): mccomponents::kernels::He3(p) {}
@@ -48,9 +44,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/detector/testHe3Tube.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/detector/testHe3Tube.cc
@@ -17,10 +17,6 @@
 #include "mccomponents/physics/constants.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 class MCA: public mccomponents::detector::AbstractMultiChannelAnalyzer {
 public:
   void accept( const channels_t & channels, double n ) 
@@ -64,9 +60,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/detector/testTof2Channel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/detector/testTof2Channel.cc
@@ -15,10 +15,6 @@
 #include <cassert>
 #include "mccomponents/kernels/detector/Tof2Channel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 void test1()
 {
@@ -34,9 +30,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/detector/testZ2Channel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/detector/testZ2Channel.cc
@@ -15,10 +15,6 @@
 #include <cassert>
 #include "mccomponents/kernels/detector/Z2Channel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 void test1()
 {
@@ -42,9 +38,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  // journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/diffraction/test_SimplePowderDiffractionKernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/diffraction/test_SimplePowderDiffractionKernel.cc
@@ -10,10 +10,6 @@
 #include "mccomponents/kernels/sample/diffraction/SimplePowderDiffractionData.h"
 #include "mccomponents/kernels/sample/diffraction/SimplePowderDiffractionKernel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 void test1()
 {
@@ -68,10 +64,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-  //journal::debug_t("SimplePowderDiffractionKernel").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/diffraction/test_SingleCrystalDiffractionKernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/diffraction/test_SingleCrystalDiffractionKernel.cc
@@ -9,10 +9,6 @@
 #include "mccomponents/math/random.h"
 #include "mccomponents/kernels/sample/diffraction/SingleCrystalDiffractionKernel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 void test1()
 {
   using namespace mccomponents::kernels;
@@ -67,10 +63,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-  journal::debug_t("SingleCrystalDiffractionKernel").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/phonon/test_CoherentInelastic_PolyXtal.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/phonon/test_CoherentInelastic_PolyXtal.cc
@@ -1,7 +1,5 @@
 #include <cassert>
 
-#include "journal/debug.h"
-
 #include "CoherentInelastic_PolyXtal_Example.h"
 
 
@@ -50,12 +48,6 @@ void runTests(w_t & kernel)
 
 int main()
 {
-
-#ifdef DEEPDEBUG
-  journal::debug_t debug( "phonon_coherent_inelastic_polyxtal_kernel" );
-  debug.activate();
-#endif
-
   w_t_Example example;
   
   w_t & kernel = example.kernel;

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/phonon/test_CoherentInelastic_SingleXtal.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/phonon/test_CoherentInelastic_SingleXtal.cc
@@ -1,7 +1,5 @@
 #include <cassert>
 
-#include "journal/debug.h"
-
 #include "CoherentInelastic_SingleXtal_Example.h"
 
 
@@ -41,12 +39,6 @@ void runTests(w_t &kernel)
 
 int main()
 {
-  journal::debug_t debug("CoherentInelastic_SingleXtal");
-  debug.activate();
-  // journal::debug_t debug2("Omega_minus_deltaE");
-  // debug2.activate();
-  journal::debug_t debug3("Omega_minus_deltaE ctor");
-  debug3.activate();
   // Create kernel
   w_t_Example example;
   w_t & kernel = example.kernel;

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/phonon/test_interpolation.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/phonon/test_interpolation.cc
@@ -16,10 +16,6 @@
 #include "mcni/test/assert.h"
 #include "mccomponents/kernels/sample/phonon/interpolate.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 struct functor {
   double a, b, c, d, e, f, g, h;
@@ -59,9 +55,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_Broadened_E_Q_Kernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_Broadened_E_Q_Kernel.cc
@@ -17,10 +17,6 @@
 
 // #define DEBUG
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 struct E_Q {
   double operator() (double Q) const
@@ -79,13 +75,6 @@ void test1()
     double vfl = vf.length();
     double Ef = conversion::v2E(vfl);
     double E = Ei-Ef;
-#ifdef DEBUG
-    std::cout << "Q=" << Q << ", "
-	      << "E=" << E << ", "
-	      << "n=" << n << ", "
-	      << "dE=" << E-Q*Q/3.
-	      << std::endl;
-#endif
   }
   
 }
@@ -93,9 +82,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  journal::debug_t("Broadened_E_Q_Kernel").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_DGSSXResKernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_DGSSXResKernel.cc
@@ -8,11 +8,6 @@
 #define DEBUG // hack
 #include "mccomponents/kernels/sample/DGSSXResKernel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 
 void test1()
 {
@@ -68,9 +63,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  journal::debug_t("DGSSXResKernel").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_E_Q_Kernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_E_Q_Kernel.cc
@@ -17,11 +17,6 @@
 
 // #define DEBUG
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 struct E_Q {
   double operator() (double Q) const
   {
@@ -85,9 +80,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  journal::debug_t("E_Q_Kernel").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_E_vQ_Kernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_E_vQ_Kernel.cc
@@ -18,10 +18,6 @@
 // #define DEBUG // hack
 #include "mccomponents/kernels/sample/E_vQ_Kernel.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 struct Const_E_vQ {
   double operator() (double Qx, double Qy, double Qz) const
@@ -158,9 +154,6 @@ void test2()
 
 int main()
 {
-#ifdef DEBUG
-  journal::debug_t("E_vQ_Kernel").activate();
-#endif
   test1();
   test2();
   return 0;

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_LorentzianBroadened_E_Q_Kernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_LorentzianBroadened_E_Q_Kernel.cc
@@ -9,10 +9,6 @@
 
 #define DEBUG
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 struct E_Q {
   double operator() (double Q) const
   {
@@ -83,9 +79,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  journal::debug_t("LorentzianBroadened_E_Q_Kernel").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SQAdaptor.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SQAdaptor.cc
@@ -16,10 +16,6 @@
 #include "mccomponents/kernels/sample/SQkernel.h"
 #include "mccomponents/kernels/sample/SQAdaptor.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 class TSQ {
 public:
@@ -58,9 +54,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SQE_fromexpression.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SQE_fromexpression.cc
@@ -17,11 +17,6 @@
 #include "mccomponents/kernels/sample/SQE/SQE_fromexpression.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 void test1()
 {
   using namespace mccomponents::sample;

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SQkernel.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SQkernel.cc
@@ -16,10 +16,6 @@
 #include "mccomponents/kernels/sample/SQkernel.h"
 #include "mccomponents/kernels/sample/AbstractSQ.h"
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 void test1()
 {
@@ -56,9 +52,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //journal::debug_t("HomogeneousNeutronScatterer").activate();
-#endif
   test1();
   return 0;
 }

--- a/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SvQ_fromexpression.cc
+++ b/packages/mccomponents/tests/libmccomponents/kernels/sample/test_SvQ_fromexpression.cc
@@ -17,11 +17,6 @@
 #include "mccomponents/kernels/sample/SQE/SvQ_fromexpression.h"
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
-
 void test1()
 {
   using namespace mccomponents::sample;

--- a/packages/mccomponents/tests/libmccomponents/math/geometry/test_choose_direction.cc
+++ b/packages/mccomponents/tests/libmccomponents/math/geometry/test_choose_direction.cc
@@ -17,8 +17,6 @@
 #include "mcni/test/assert.h"
 #include "mccomponents/math/random/geometry.h"
 
-#include "journal/debug.h"
-
 using namespace std;
 using namespace mccomponents::math;
 char * jrnltag ="test_choose_direction";
@@ -201,10 +199,6 @@ void test3()
 
 int main()
 {
-#ifdef DEBUG
-  //  journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-  //  journal::debug_t(jrnltag).activate();
-#endif
   test1();
   test2();
   test3();

--- a/packages/mccomponents/tests/libmccomponents/math/random/test_gaussian.cc
+++ b/packages/mccomponents/tests/libmccomponents/math/random/test_gaussian.cc
@@ -17,7 +17,6 @@
 #include "mcni/test/assert.h"
 #include "mccomponents/math/random/gaussian.h"
 
-#include "journal/debug.h"
 
 void test1()
 {
@@ -48,10 +47,6 @@ void test1()
 
 int main()
 {
-#ifdef DEBUG
-  //  journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-  //  journal::debug_t(jrnltag).activate();
-#endif
   test1();
 }
 

--- a/packages/mccomposite/lib/geometry/intersect.icc
+++ b/packages/mccomposite/lib/geometry/intersect.icc
@@ -16,7 +16,6 @@
 #else
 
 #include "locate.h"
-#include "journal/debug.h"
 #include "mccomposite/geometry/shape2ostream.h"
 #include "mccomposite/vector2ostream.h"
 
@@ -41,9 +40,6 @@ namespace mccomposite {
     ( const Position & start, const Direction & direction, 
       const std::vector<const AbstractShape *> & shapes )  
     {
-#ifdef DEBUG
-      journal::debug_t debug("mccomposite.geometry.intersect");
-#endif
       Arrow arrow(start, direction);
       Union all(shapes);
       index_t ret;
@@ -51,11 +47,6 @@ namespace mccomposite {
       // We need to determine intersections anyway
       ArrowIntersector::distances_t distances = 
 	forward_intersect( arrow, all );
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "forward intersections: " << distances
-	    << journal::endl;
-#endif
       // number of intersections
       size_t nIntersections = distances.size();
 
@@ -73,11 +64,6 @@ namespace mccomposite {
       // determine which one of the above two cases is true,
       // case1:
       if (nIntersections % 2 == 1) {
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "case1"
-	    << journal::newline;
-#endif
 	Position middle_of_start_and_intersection1 = 
 	  start + (distances[0]/2.)*direction;
 	ret = find_shape_containing_point<index_t>
@@ -85,11 +71,6 @@ namespace mccomposite {
       }
       // case2:
       else {
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "case2"
-	    << journal::newline;
-#endif
 	// no intersection
 	if (nIntersections==0) return -1;
 	// at least two
@@ -99,11 +80,6 @@ namespace mccomposite {
 	  (middle_of_intersection1_and_intersection2, shapes);
       }
 
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "preliminary result of shape index : " << ret
-	    << journal::endl;
-#endif
 
       // let us determine if the start is on border
       bool isonborder = 0;
@@ -113,12 +89,6 @@ namespace mccomposite {
 	  { isonborder = 1; break; }
       }
       
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "is the starting point " << start 
-	    << " on border of any shape? " << isonborder
-	    << journal::endl;
-#endif
 
       // If start is not on border of any shape, it would be easier.
       if (!isonborder) return ret;
@@ -132,14 +102,6 @@ namespace mccomposite {
 	now = distances[point_index];
 	Position middle_point = start + (previous + now)/2*direction;
 	ret = find_shape_containing_point<index_t>( middle_point, shapes );
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-        << "point_index " << point_index
-        << ", now " << now
-        << ", middle_point" << middle_point
-        << ", ret" << ret
-        << journal::endl;
-#endif
 	// if (ret>=0 && ret<nIntersections) return ret;
 	if (ret>=0) return ret;
 	previous = now;

--- a/packages/mccomposite/lib/geometry/locate.cc
+++ b/packages/mccomposite/lib/geometry/locate.cc
@@ -1,5 +1,4 @@
 #include "mccomposite/geometry/locate.h"
-#include "journal/debug.h"
 #include "mccomposite/geometry/shape2ostream.h"
 
 mccomposite::geometry::Locator::Location 
@@ -10,12 +9,5 @@ mccomposite::geometry::locate
   mccomposite::geometry::Locator locator;
   locator.setPoint( position );
   Locator::Location location = locator.locate( shape );
-#ifdef DEBUG
-  journal::debug_t debug("mccomposite.geometry.Locator");
-  debug << journal::at(__HERE__)
-	<< "location of " << position << " relative to " << shape
-	<< " is " << location
-	<< journal::endl;
-#endif
   return location;
 }

--- a/packages/mccomposite/lib/geometry/overlap.cc
+++ b/packages/mccomposite/lib/geometry/overlap.cc
@@ -3,7 +3,6 @@
 #include "mccomposite/geometry/locate.h"
 #include "mccomposite/geometry/intersect.h"
 #include "mccomposite/geometry/overlap.h"
-#include "journal/debug.h"
 #include "mccomposite/geometry/shape2ostream.h"
 
 

--- a/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
+++ b/packages/mccomposite/lib/geometry/visitors/ArrowIntersector.cc
@@ -11,7 +11,6 @@
 
 #include "mccomposite/geometry/exception.h"
 
-#include "journal/debug.h"
 
 namespace ArrowIntersector_impl{
 
@@ -222,9 +221,6 @@ void
 mccomposite::geometry::ArrowIntersector::visit
 ( const Box * boxptr )
 {
-#ifdef DEBUG
-  journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-#endif
   m_distances.clear();
   
   const Box & box = *boxptr;
@@ -233,14 +229,6 @@ mccomposite::geometry::ArrowIntersector::visit
   const Direction & direction = m_arrow.direction;
   if (isInvaildDirection(direction)) return;
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "box: "<< *boxptr << journal::newline
-	<< "start: " << start << journal::newline
-	<< "direction: " << direction
-	<< journal::endl
-    ;
-#endif
   
   double x = start.x; 
   double y = start.y;
@@ -256,42 +244,18 @@ mccomposite::geometry::ArrowIntersector::visit
     intersectRectangle(x,y,z-Z/2, vx,vy,vz, X, Y, ts);
     intersectRectangle(x,y,z+Z/2, vx,vy,vz, X, Y, ts);
   }
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< ts << journal::endl
-    ;
-#endif
   if (vx!=0) {
     intersectRectangle(y,z,x-X/2, vy,vz,vx, Y, Z, ts);
     intersectRectangle(y,z,x+X/2, vy,vz,vx, Y, Z, ts);
   }
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< ts << journal::endl
-    ;
-#endif
   if (vy!=0) {
     intersectRectangle(z,x,y-Y/2, vz,vx,vy, Z, X, ts);
     intersectRectangle(z,x,y+Y/2, vz,vx,vy, Z, X, ts);
   }
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< ts << journal::endl
-    ;
-#endif
   
   if (!ts.size()) return;
   if (ts.size() == 1) {
     // this is usually due to numerical errors
-#ifdef DEBUG
-    debug
-      << journal::at(__HERE__)
-      << "number of intersections between a line and a box should be 0 or 2, "
-      << "we got " << ts.size() << ". " << journal::newline
-      << "box: " << box << ", "
-      << "arrow: " << m_arrow
-      << journal::endl;
-#endif
     return;
   }
   if (ts.size()!=2) {
@@ -314,11 +278,6 @@ mccomposite::geometry::ArrowIntersector::visit
     m_distances.push_back(ts[0]);
   }
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< m_distances << journal::endl
-    ;
-#endif
 
   return ;
 }
@@ -329,9 +288,6 @@ void
 mccomposite::geometry::ArrowIntersector::visit
 ( const Pyramid * pyramidptr )
 {
-#ifdef DEBUG
-  journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-#endif
   m_distances.clear();
   
   const Pyramid & pyramid = *pyramidptr;
@@ -342,14 +298,6 @@ mccomposite::geometry::ArrowIntersector::visit
   double length = direction.length();
   direction= direction * (1./length); // normalize
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "pyramid: "<< *pyramidptr << journal::newline
-	<< "start: " << start << journal::newline
-	<< "direction: " << direction
-	<< journal::endl
-    ;
-#endif
   
   double x = start.x; 
   double y = start.y;
@@ -381,11 +329,6 @@ mccomposite::geometry::ArrowIntersector::visit
 		    Position(0, 0, 0), Position(-X/2, Y/2, -H), Position(X/2, Y/2, -H),
 		    ts);
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< ts << journal::endl
-    ;
-#endif
 
   if (!ts.size()) return;
   // remove duplicates
@@ -396,18 +339,6 @@ mccomposite::geometry::ArrowIntersector::visit
   //
   if (N == 1) {
     // this is usually due to numerical errors
-#ifdef DEBUG
-    debug
-      << journal::at(__HERE__)
-      << "number of intersections between a line and a pyramid should be 0 or 2, "
-      << "we got " << N << ". " << journal::newline;
-    for (std::vector<double>::iterator it=ts.begin(); it!=new_end; it++)
-      debug << *it << ", ";
-    debug << journal::endl
-      << "pyramid: " << pyramid << ", "
-      << "arrow: " << m_arrow
-      << journal::endl;
-#endif
     return;
   }
   if (N!=2) {
@@ -433,11 +364,6 @@ mccomposite::geometry::ArrowIntersector::visit
     m_distances.push_back(ts[0]/length);
   }
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< m_distances << journal::endl
-    ;
-#endif
   return ;
 }
 
@@ -447,9 +373,6 @@ void
 mccomposite::geometry::ArrowIntersector::visit
 ( const Cone * coneptr )
 {
-#ifdef DEBUG
-  journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-#endif
   m_distances.clear();
   
   const Cone & cone = *coneptr;
@@ -460,14 +383,6 @@ mccomposite::geometry::ArrowIntersector::visit
   double length = direction.length();
   direction = direction * (1./length); // normalize
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "cone: "<< *coneptr << journal::newline
-	<< "start: " << start << journal::newline
-	<< "direction: " << direction
-	<< journal::endl
-    ;
-#endif
   
   double x = start.x; 
   double y = start.y;
@@ -497,13 +412,6 @@ mccomposite::geometry::ArrowIntersector::visit
   double b = 2 * (DdotV*COdotV - DdotCO * cos_theta_sq);
   double c = COdotV*COdotV - (CO|CO)  * cos_theta_sq;
   double t1[2]; int N=0;  // temp array to hold t values for the infinite cone
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "DdotV=" << DdotV << ", COdotV=" << COdotV << ", DdotCO=" << DdotCO << journal::newline
-	<< "a=" << a << ", b=" << b << ", c=" << c << journal::newline
-	<< journal::endl
-    ;
-#endif
   
   if (eq_withinepsilon(a, 0.)) {
     if (eq_withinepsilon(b, 0.)) {
@@ -521,12 +429,6 @@ mccomposite::geometry::ArrowIntersector::visit
       t1[1] = (-b+std::sqrt(delta))/2./a/vl;
     }
   }
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "t1=" << journal::newline;
-  for (int i=0; i<N; i++) debug << t1[i] << ", ";
-  debug << journal::endl;
-#endif
   // limit the cone to be between z=0 and z=-H
   for (int i=0; i<N; i++) {
     // compute z
@@ -539,12 +441,6 @@ mccomposite::geometry::ArrowIntersector::visit
   double x2 = x + vx*t2, y2 = y + vy*t2;
   if (x2*x2+y2*y2 < R*R) ts.push_back(t2);
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "ts=" << journal::newline;
-  for (int i=0; i<ts.size(); i++) debug << ts[i] << ", ";
-  debug << journal::endl;
-#endif
   
   if (!ts.size()) return;
   // remove duplicates
@@ -596,11 +492,6 @@ mccomposite::geometry::ArrowIntersector::visit
     m_distances.push_back(ts[0]/length);
   }
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< m_distances << journal::endl
-    ;
-#endif
   return ;
 }
 
@@ -609,9 +500,6 @@ void
 mccomposite::geometry::ArrowIntersector::visit
 ( const Cylinder * cylptr )
 {
-#ifdef DEBUG
-  journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-#endif
 
   m_distances.clear();
   
@@ -621,14 +509,6 @@ mccomposite::geometry::ArrowIntersector::visit
   const Direction & direction = m_arrow.direction;
   if (isInvaildDirection(direction)) return;
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< "cylinder: "<< cylinder << journal::newline
-	<< "start: " << start << journal::newline
-	<< "direction: " << direction
-	<< journal::endl
-    ;
-#endif
   
   double x = start.x; 
   double y = start.y;
@@ -644,19 +524,9 @@ mccomposite::geometry::ArrowIntersector::visit
   std::vector<double> ts;
   // side
   intersectCylinderSide(x,y,z, vx,vy,vz, r, h, ts);
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< ts << journal::endl
-    ;
-#endif
 
   // top/bottom
   intersectCylinderTopBottom(x,y,z, vx,vy,vz, r, h, ts);
-#ifdef DEBUG
-  debug << journal::at(__HERE__) 
-	<< ts << journal::endl
-    ;
-#endif
   
   if (ts.size()==0) return;
   
@@ -782,19 +652,6 @@ namespace ArrowIntersector_impl{
     {
       bool ret = locate( m_arrow.start + distance * m_arrow.direction, m_shape ) != Locator::onborder;
 
-#ifdef DEBUG
-      journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-      
-      debug << journal::at(__HERE__) 
-	    << "start = " << m_arrow.start << journal::newline
-	    << "direction = " << m_arrow.direction << journal::newline
-	    << "distance = " << distance << journal::newline
-	    << "point = " << m_arrow.start + distance * m_arrow.direction << journal::newline
-	    << "shape = " << m_shape << journal::newline
-	    << "isNotOnBorder = " << ret
-	    << journal::endl;
-      ;
-#endif
       return ret;
     }
     
@@ -850,17 +707,6 @@ mccomposite::geometry::ArrowIntersector::visit_composition
 //   copy( distances.begin(), newend, std::back_inserter(m_distances) );
   copy( distances.begin(), distances.end(), std::back_inserter(m_distances) );
 
-#ifdef DEBUG
-  journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-
-  debug << journal::at(__HERE__) 
-	<< "intersections between " 
-	<< "arrow(" << m_arrow.start << "," << m_arrow.direction << ")"
-	<< " and shape (" << *composition << ")"
-	<< " are "
-	<< m_distances << journal::endl
-    ;
-#endif
 
   //
   //  if (m_distances.size()%2==1) throw Exception("odd number of intersections");
@@ -901,13 +747,6 @@ mccomposite::geometry::ArrowIntersector::visit
   
   body.identify( *this );
 
-#ifdef DEBUG
-  journal::debug_t debug( ArrowIntersector_impl::jrnltag );
-
-  debug << journal::at(__HERE__) 
-	<< m_distances << journal::endl
-    ;
-#endif
 
   m_arrow = save;
   //

--- a/packages/mccomposite/lib/geometry/visitors/BoundingBoxMaker.cc
+++ b/packages/mccomposite/lib/geometry/visitors/BoundingBoxMaker.cc
@@ -3,7 +3,6 @@
 #include "mccomposite/geometry/shape2ostream.h"
 #include "mccomposite/exception.h"
 
-#include "journal/debug.h"
 
 
 namespace BoundingBoxMaker_impl{

--- a/packages/mccomposite/lib/geometry/visitors/Locator.cc
+++ b/packages/mccomposite/lib/geometry/visitors/Locator.cc
@@ -2,7 +2,6 @@
 #include "mccomposite/geometry/shape2ostream.h"
 #include "mccomposite/exception.h"
 
-#include "journal/debug.h"
 
 
 namespace Locator_impl{

--- a/packages/mccomposite/lib/mccomposite/CompositeNeutronScatterer_Impl.cc
+++ b/packages/mccomposite/lib/mccomposite/CompositeNeutronScatterer_Impl.cc
@@ -11,12 +11,6 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //
 
-// #define DEBUG
-// #define DEBUG_MULTIPLESCATTERING
-
-#ifdef DEBUG
-#define DEBUG_MULTIPLESCATTERING
-#endif
 
 #include <vector>
 #include "mccomposite/CompositeNeutronScatterer_Impl.h"
@@ -26,7 +20,6 @@
 #include "mccomposite/geometry/shape2ostream.h"
 #include "mccomposite/neutron_propagation.h"
 
-#include "journal/debug.h"
 #include "mccomposite/vector2ostream.h"
 
 namespace mccomposite {
@@ -187,9 +180,6 @@ mccomposite::CompositeNeutronScatterer_Impl::calculate_attenuation
 (const mcni::Neutron::Event & ev, const geometry::Position & end)
 {
   using namespace CompositeNeutronScatterer_ImplDetails;
-#ifdef DEBUG
-  journal::debug_t debug( jrnltag );
-#endif
 
   double ret = 1.;
   mcni::Neutron::Event ev1;
@@ -200,22 +190,10 @@ mccomposite::CompositeNeutronScatterer_Impl::calculate_attenuation
     AbstractNeutronScatterer & scatterer = *(m_scatterers[scatterer_index]);
     ev1 = ev;
 
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "scatterer id = " << scatterer_index
-	  << ", its shape = " << scatterer.shape()
-	  << journal::endl;
-#endif
     
     // convert to local coords
     m_details->global2local(ev1, scatterer);
     
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "event = " << ev
-	  << ", converted to local coordiante: " << ev1
-	  << journal::endl;
-#endif
     //
     ret *= scatterer.calculate_attenuation( ev1, end );
   }
@@ -232,9 +210,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
   using namespace CompositeNeutronScatterer_ImplDetails;
   typedef int index_t;
   
-#ifdef DEBUG
-  journal::debug_t debug( jrnltag );
-#endif
   
   mcni::Neutron::Event ev1 = ev;
   
@@ -252,11 +227,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
   
   while (to_be_scattered.size()>0 && nloop++<max_multiplescattering_loops_interactM_path1) {
     
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "to_be_scattered neutrons: " << to_be_scattered 
-	  << journal::endl;
-#endif
     mcni::Neutron::Events to_be_scattered2;
     
     for (size_t i=0; i<to_be_scattered.size(); i++) {
@@ -264,11 +234,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
       // for each event
       const mcni::Neutron::Event & ev = to_be_scattered[i];
       
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "now dealing with neutron " << ev
-	    << journal::endl;
-#endif
       // if the neutron probability is too low, skip
       if (ev.probability >= 0 && ev.probability < min_neutron_probability)
 	continue;
@@ -277,11 +242,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
       index_t scatterer_index = find_1st_hit<index_t>
 	( ev.state.position, ev.state.velocity, m_shapes );
       
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "1st scatterer encountered is scatterer # " << scatterer_index
-	    << journal::endl;
-#endif
       
       // no hit, that event will go out. so add that to the out-list
       if (scatterer_index<0 or scatterer_index>=m_scatterers.size()) 
@@ -291,11 +251,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
       // 1. the scattterer
       AbstractNeutronScatterer & scatterer = *(m_scatterers[scatterer_index]);
       
-#ifdef DEBUG
-      debug << journal::at(__HERE__)
-	    << "The scatterer has shape: " << scatterer.shape()
-	    << journal::endl;
-#endif
       
       // 2. the scattered neutrons will be stored here
       mcni::Neutron::Events newly_scattered;
@@ -304,22 +259,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
       m_details->global2local( local_event, scatterer );
       // 4. scatter
       itype = scatterer.interactM_path1( local_event, newly_scattered );
-#ifdef DEBUG
-      debug << journal::at(__HERE__);
-      if (newly_scattered.size()) {
-	debug << "After interactM_path1 by scatterer ";
-	debug << scatterer;
-	debug << ", got "
-	      << newly_scattered.size()
-	      << " new neutrons: "
-	      << journal::newline;
-	for (int i=0; i<newly_scattered.size(); i++) 
-	  debug << newly_scattered[i] << journal::newline;
-      } else {
-	debug << "After interactM_path1, got no new neutrons.";
-      }
-      debug << journal::endl;
-#endif
       
       // absorbed. nothing to do
       if (itype == scatterer_interface::absorption)
@@ -328,48 +267,24 @@ mccomposite::CompositeNeutronScatterer_Impl::interactM_path1
       // if we reach here, that means we got some new neutrons
       // 1. convert neutrons back to global coordinate
       m_details->local2global( newly_scattered, scatterer );
-#ifdef DEBUG
-      debug << journal::at(__HERE__);
-      debug << "Convertrf neutrons after interactM_path1 back to global coords:"
-	    << journal::newline;
-      for (int i=0; i<newly_scattered.size(); i++) 
-	debug << newly_scattered[i] << journal::newline;
-      debug << journal::endl;
-#endif
       
       // 2. we need to check those neutrons. 
       // some of them may already exited first surface. we just need
       // to add to the out-list. The rest we need to deal with them
       // scatter them again.
-#ifdef DEBUG
-      debug << journal::at(__HERE__);
-      debug << "Now check neutrons." << journal::newline;
-#endif
       for (size_t new_neutron_index = 0; new_neutron_index < newly_scattered.size();
 	   new_neutron_index++ ) {
 	const mcni::Neutron::Event & ev = newly_scattered[new_neutron_index];
 	
-#ifdef DEBUG
-	debug << new_neutron_index << ": " << ev << journal::newline;
-#endif
 	
 	// exited. add it to the out-list
 	if (locate(ev, m_shape) != Locator::inside) { 
-#ifdef DEBUG
-	debug << "+ " << "exited" << journal::newline;
-#endif
 	    evts.push_back(ev); continue; 
 	}
 	
 	// not exited. need to scatter again.
-#ifdef DEBUG
-	debug << "+ " << "saved to be scattered latter" << journal::newline;
-#endif
 	to_be_scattered2.push_back( ev );
       }
-#ifdef DEBUG
-      debug << journal::endl;
-#endif
       
     }
     
@@ -407,13 +322,6 @@ mccomposite::CompositeNeutronScatterer_Impl::scatterM
   using namespace geometry;
   typedef int index_t;
   
-#ifdef DEBUG_MULTIPLESCATTERING
-  journal::debug_t debug( jrnltag );
-  debug << journal::at(__HERE__)
-	<< "entering scatterM: "
-	<< "event:" << ev
-	<< journal::endl;
-#endif
   
   mcni::Neutron::Events scattered;
   scattered.push_back( ev );
@@ -427,13 +335,6 @@ mccomposite::CompositeNeutronScatterer_Impl::scatterM
     
     mcni::Neutron::Events scattered2;
     
-#ifdef DEBUG_MULTIPLESCATTERING2
-    debug << journal::at(__HERE__)
-	  << "in 'while loop' #" << nloop << journal::newline
-	  << "input neutron events:"
-	  << scattered
-	  << journal::endl;
-#endif
 
     // loop over neutrons and compute scattered and transmitted
     // neutrons and put them into scattered2
@@ -453,30 +354,13 @@ mccomposite::CompositeNeutronScatterer_Impl::scatterM
       // if not, it should be let go.
       
       if (is_exiting( ev, m_shape ) ) {
-#ifdef DEBUG_MULTIPLESCATTERING2
-	debug << journal::at(__HERE__)
-	      << "this neutron is going out: " << ev 
-	      << journal::endl;
-#endif
 	evts.push_back( ev ); continue; 
       }
       
-#ifdef DEBUG_MULTIPLESCATTERING2
-      debug << journal::at(__HERE__)
-	    << "this neutron needs further scattering: " << ev 
-	    << journal::endl;
-#endif
       
       // try to scatter the neutron 
       itype = interactM_path1( ev, scattered2 );
       
-#ifdef DEBUG_MULTIPLESCATTERING2
-      debug << journal::at(__HERE__)
-	    << "interactM_path1"
-	    << "scattered event " << ev 
-	    << "into " << scattered2
-	    << journal::endl;
-#endif
       // if there is an event that does not really get scattered
       // we have a problem
       if (scattered2.size()==1) {
@@ -488,13 +372,6 @@ mccomposite::CompositeNeutronScatterer_Impl::scatterM
 	  propagate(ev2, 1e-7);
 	}
 
-#ifdef DEBUG_MULTIPLESCATTERING2
-	debug << journal::at(__HERE__)
-	      << "after ajdustment, interactM_path1"
-	      << "scattered event " << ev 
-	      << "into " << scattered2
-	      << journal::endl;
-#endif
       }
 
       // absorbed. nothing to do
@@ -506,13 +383,6 @@ mccomposite::CompositeNeutronScatterer_Impl::scatterM
     // be further scattered
     scattered.swap( scattered2 );
 
-#ifdef DEBUG_MULTIPLESCATTERING
-    debug << journal::at(__HERE__)
-	  << "in 'while loop' #" << nloop << journal::newline
-	  << "output neutron events:"
-	  << scattered
-	  << journal::endl;
-#endif
   } // end of while loop 
   
   // there could be left-over neutrons 
@@ -539,27 +409,13 @@ mccomposite::CompositeNeutronScatterer_Impl::interact_path1
 (mcni::Neutron::Event & ev)
 {
   using namespace CompositeNeutronScatterer_ImplDetails;
-#ifdef DEBUG
-  journal::debug_t debug( jrnltag );
-#endif
   
   using namespace geometry;
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "trying to find 1st hit of neutron " << ev
-	<< " w.r.t shapes " << geometry::Union( m_shapes )
-	<< journal::endl;
-#endif
   
   int scatterer_index = find_1st_hit<int>
     ( ev.state.position, ev.state.velocity, m_shapes );
 
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "1st hit scatterer index: " << scatterer_index
-	<< journal::endl;
-#endif
   // nothing hit. should just let go the neutron
   if (scatterer_index < 0 or scatterer_index >= m_scatterers.size() ) {
     propagate_to_next_exiting_surface( ev, m_shape );
@@ -568,48 +424,21 @@ mccomposite::CompositeNeutronScatterer_Impl::interact_path1
 
   // the scatterer
   AbstractNeutronScatterer & scatterer = *(m_scatterers[scatterer_index]);
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "scatterer shape: " << scatterer.shape()
-	<< "scatterer position, orientation: " << m_geometer.getPosition(scatterer)
-	<< ", " << m_geometer.getOrientation(scatterer)
-	<< journal::endl;
-#endif
   // need to convert event to local coords before scattering
   mcni::Neutron::Event local_event = ev;
   m_details->global2local(local_event, scatterer);
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "local event: " << local_event
-	<< journal::endl;
-#endif
   // delegate the scaterer to deal with the neutron
   scatterer_interface::InteractionType itype = scatterer.interact_path1( local_event );
   
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "interaction type: " << itype
-	<< journal::endl;
-#endif
   // this means that the neutron is absorbed
   if (itype == scatterer_interface::absorption) {
     ev.probability = -1;
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "neutron absorbed: " << ev
-	  << journal::endl;
-#endif
     return itype;
   }
   
   // now we need to convert back coordinate
   m_details->local2global( local_event, scatterer );
   ev = local_event;
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "neutron back at global coordinates: " << ev
-	<< journal::endl;
-#endif
   
   // if the neutron just passed the scatterer without scattering
   if (itype == scatterer_interface::none) {
@@ -619,11 +448,6 @@ mccomposite::CompositeNeutronScatterer_Impl::interact_path1
       return itype;
     // if still insdie the composite, 
     // then we need to do scattering again
-#ifdef DEBUG
-    debug << journal::at(__HERE__)
-	  << "neutron needs more interaction: " << ev
-	  << journal::endl;
-#endif
     return interact_path1( ev );
   }
   
@@ -635,20 +459,9 @@ mccomposite::CompositeNeutronScatterer_Impl::interact_path1
   // 2. propagate to surface if necessary
   if (locate(ev, m_shape) == Locator::inside) 
     propagate_to_next_exiting_surface( ev, m_shape );
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "neutron propagated to next out surface: " << ev
-	<< journal::endl;
-#endif
   // 3. compute attenuation
   double attenuation = calculate_attenuation( save, ev.state.position );
   ev.probability *= attenuation;
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "attenuation: " << attenuation << ", "
-	<< "neutron attenuated: " << ev
-	<< journal::endl;
-#endif
   
   return scatterer_interface::scattering;
 }
@@ -659,25 +472,16 @@ mccomposite::CompositeNeutronScatterer_Impl::scatter
 (mcni::Neutron::Event & ev)
 {
   using namespace CompositeNeutronScatterer_ImplDetails;
-#ifdef DEBUG
-  journal::debug_t debug( jrnltag );
-#endif
 
   using namespace geometry;
 
   // if the neutron is not moving, we don't have a way to deal with it
   if (! is_moving( ev ) ) {
-#ifdef DEBUG
-    debug << "neutron is not moving. exit." << journal::endl;
-#endif
     ev.probability = -1; return;
   }
       
   // event is exiting, nothing need to be done
   if (is_exiting(ev, m_shape)) {
-#ifdef DEBUG
-    debug << "neutron is exiting the scatterer." << journal::endl;
-#endif
     return;
   }
   // event does not really hit me, return
@@ -685,32 +489,20 @@ mccomposite::CompositeNeutronScatterer_Impl::scatter
   // might not be the union of all element shapes. 
   // so the event might hit the "frame shape", but not really any scatterer
   if (is_exiting(ev, m_union_of_all_shapes)) {
-#ifdef DEBUG
-    debug << "neutron is exiting all subcomponents." << journal::endl;
-#endif
     propagate_to_next_exiting_surface( ev, m_shape );
     return;
   }
 
   // otherwise, interacts once.
-#ifdef DEBUG
-  debug << "Let neutron interact with this scatterer once." << journal::endl;
-#endif
   scatterer_interface::InteractionType itype = interact_path1( ev );
   
   // if it is absorbed or it does not hit anything. we don't
   // need do more.
   if (itype == scatterer_interface::absorption) {
-#ifdef DEBUG
-    debug << "neutron is absorbed." << journal::endl;
-#endif
     return;
   }
 
   if (itype == scatterer_interface::none) {
-#ifdef DEBUG
-    debug << "propagate to next incident surface and scatter" << journal::endl;
-#endif
     // need to call scatter again
     propagate_to_next_incident_surface( ev, m_union_of_all_shapes );
     scatter( ev );
@@ -720,24 +512,15 @@ mccomposite::CompositeNeutronScatterer_Impl::scatter
   // when we reach here, this means the event was scattered. 
   // we still need to attenuate the outgoing event
   // 1. find intersections
-#ifdef DEBUG
-  debug << "event was scatterred. need to figure out attenuations" << journal::endl;
-#endif
   tofs_t tofs = intersect(ev, m_shape);
   
   // 2. no intersection. nothing to do
   if (tofs.size()==0) {
-#ifdef DEBUG
-    debug << "no intersections, no attenuation. scatter done" << journal::endl;
-#endif
     return;
   }
 
   // 3. with intersection. propagate to the last intersection and 
   // attenuate the neutron.
-#ifdef DEBUG
-  debug << "has intersections. propagate to the next intersection and attenuate." << journal::endl;
-#endif
   // 3a. save the neutron
   mcni::Neutron::Event save = ev;
   // 2. propagate out
@@ -745,12 +528,6 @@ mccomposite::CompositeNeutronScatterer_Impl::scatter
   // 3. compute attenuation
   double attenuation = calculate_attenuation( save, ev.state.position );
   ev.probability *= attenuation;
-#ifdef DEBUG
-  debug << journal::at(__HERE__)
-	<< "attenuation: " << attenuation << ", "
-	<< "neutron attenuated: " << ev
-	<< journal::endl;
-#endif
   
   return;
 }

--- a/packages/mccomposite/lib/mccomposite/Geometer.icc
+++ b/packages/mccomposite/lib/mccomposite/Geometer.icc
@@ -16,10 +16,6 @@
 #else
 
 
-#ifdef DEBUG
-#include "journal/debug.h"
-#endif
-
 
 namespace mccomposite { 
   namespace Geometer_Impl {
@@ -39,13 +35,6 @@ void
 mccomposite::Geometer<element_t>::remember
 ( const element_t & element, const position_t & position, const orientation_t & orientation)
 {
-#ifdef DEBUG
-  journal::debug_t debug( Geometer_Impl::jrnltag );
-  debug << journal::at(__HERE__)
-	<< "position: " << position << ", "
-	<< "orientation: " << orientation
-	<< journal::endl;
-#endif
   m_e2info[ &element ] = info_t( position, orientation );
 }
     

--- a/packages/mccomposite/mccompositebpmodule/mccompositebp.cc
+++ b/packages/mccomposite/mccompositebpmodule/mccompositebp.cc
@@ -13,7 +13,6 @@
 
 
 #include <boost/python.hpp>
-#include "journal/debug.h"
 
 namespace wrap_mccomposite{
   void wrap_basics();
@@ -36,7 +35,6 @@ namespace wrap_mccomposite{
 BOOST_PYTHON_MODULE(mccompositebp)
 {
   char jrnltag[] = "mccompositebp";
-  journal::debug_t debug(jrnltag);
 
   using namespace boost::python;
   using namespace wrap_mccomposite;

--- a/packages/mccomposite/tests/libmccomposite/geometry/testArrowIntersector.cc
+++ b/packages/mccomposite/tests/libmccomposite/geometry/testArrowIntersector.cc
@@ -21,8 +21,6 @@
 #include "mcni/geometry/Vector3.h"
 #include "mcni/geometry/Position.h"
 
-#include "journal/debug.h"
-
 namespace {
   using namespace std;
   using namespace mccomposite::geometry;
@@ -249,13 +247,6 @@ void test5()
 
   ArrowIntersector::distances_t distances = intersect(arrow, diff);
 
-#ifdef DEBUG
-  journal::debug_t debug(jrnltag);
-  debug << journal::at (__HERE__) 
-	<< distances
-	<< journal::endl;
-#endif
-
   assert (distances.size() == 4);
   assert (distances[0] == 4 );
   assert (distances[1] == 4.5 );
@@ -331,12 +322,6 @@ void test10()
 
 int main()
 {
-  // define DEBUG on top of this file to enable debugging
-#ifdef DEBUG
-  journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-//   journal::debug_t("mccomposite.geometry.Locator").activate();
-//   journal::debug_t(jrnltag).activate();
-#endif
   test1();
   test2();
   test3();

--- a/packages/mccomposite/tests/libmccomposite/geometry/test_intersect.cc
+++ b/packages/mccomposite/tests/libmccomposite/geometry/test_intersect.cc
@@ -18,8 +18,6 @@
 #include "mccomposite/geometry/shapes.h"
 #include "mccomposite/geometry/intersect.h"
 
-#include "journal/debug.h"
-
 using namespace std;
 using namespace mccomposite::geometry;
 char * jrnltag ="test_intersect";
@@ -380,12 +378,6 @@ void test10()
 
 int main()
 {
-#ifdef DEBUG
-  //  journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-//   journal::debug_t("mccomposite.geometry.Locator").activate();
-//   journal::debug_t("mccomposite.geometry.intersect").activate();
-//   journal::debug_t(jrnltag).activate();
-#endif
   test1();
   test2();
   test3();

--- a/packages/mccomposite/tests/libmccomposite/geometry/test_intersect_cone.cc
+++ b/packages/mccomposite/tests/libmccomposite/geometry/test_intersect_cone.cc
@@ -10,7 +10,6 @@
 #include "mccomposite/geometry/shapes.h"
 #include "mccomposite/geometry/intersect.h"
 
-#include "journal/debug.h"
 
 using namespace std;
 using namespace mccomposite::geometry;
@@ -69,11 +68,6 @@ void test2()
 
 int main()
 {
-#ifdef DEBUG
-//  journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-//   journal::debug_t("mccomposite.geometry.Locator").activate();
-//   journal::debug_t("mccomposite.geometry.intersect").activate();
-#endif
   test1();
   test1a();
   test2();

--- a/packages/mccomposite/tests/libmccomposite/mccomposite/testAbstractNeutronScatterer.cc
+++ b/packages/mccomposite/tests/libmccomposite/mccomposite/testAbstractNeutronScatterer.cc
@@ -125,9 +125,6 @@ void test3()
 
 int main()
 {
-//   journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-//   journal::debug_t("mccomposite.geometry.Locator").activate();
-//    journal::debug_t("CompositeNeutronScatterer_Impl").activate();
  test1();
  test2();
   test3();

--- a/packages/mccomposite/tests/libmccomposite/mccomposite/testCompositeNeutronScatterer.cc
+++ b/packages/mccomposite/tests/libmccomposite/mccomposite/testCompositeNeutronScatterer.cc
@@ -414,11 +414,6 @@ void test10()
 
 int main()
 {
-#ifdef DEBUG
-//   journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-//   journal::debug_t("mccomposite.geometry.Locator").activate();
-//   journal::debug_t("CompositeNeutronScatterer_Impl").activate();
-#endif
   test1();
   test2();
   test3();

--- a/packages/mccomposite/tests/libmccomposite/mccomposite/testMultipleScattering.cc
+++ b/packages/mccomposite/tests/libmccomposite/mccomposite/testMultipleScattering.cc
@@ -221,11 +221,6 @@ void test7()
 
 int main()
 {
-#ifdef DEBUG
-//   journal::debug_t("mccomposite.geometry.ArrowIntersector").activate();
-//   journal::debug_t("mccomposite.geometry.Locator").activate();
-//   journal::debug_t("CompositeNeutronScatterer_Impl").activate();
-#endif
   test6();
   test7();
 }

--- a/packages/mcni/lib/mcni/AbstractNeutronScatterer.icc
+++ b/packages/mcni/lib/mcni/AbstractNeutronScatterer.icc
@@ -16,9 +16,6 @@
 #error AbstractNeutronScatterer.icc not meaningful outside AbstractNeutronScatterer.h
 #else
 
-#include "journal/error.h"
-#include "journal/debug.h"
-
 #include "mcni/neutron.h"
 
 #include "exceptions.h"
@@ -27,12 +24,6 @@
 void 
 mcni::absorb(Neutron::Event &ev)
 {
-#ifdef DEEPDEBUG
-  journal::debug_t debug("scatter");
-  debug << journal::at(__HERE__)
-	<<"* Warning: neutron " << ev << " absorbed."
-	<< journal::endl;
-#endif
   ev.probability = -1;
 }
 

--- a/packages/mcni/lib/mcni/exceptions.h
+++ b/packages/mcni/lib/mcni/exceptions.h
@@ -17,7 +17,6 @@
 
 
 #include "mcni/test/exception.h"
-#include "journal/error.h"
 
 namespace mcni {
 
@@ -29,9 +28,7 @@ namespace mcni {
 
   // convenient methods
   inline void throw_fatal_path_error
-  ( const char *channel, const journal::loc3_t & where, const char *msg );
-  inline void throw_fatal_path_error
-  ( const char *channel, const journal::loc2_t & where, const char *msg );
+  ( const char *msg );
 }
 
 #include "exceptions.icc"

--- a/packages/mcni/lib/mcni/exceptions.icc
+++ b/packages/mcni/lib/mcni/exceptions.icc
@@ -19,16 +19,9 @@
 
 void
 mcni::throw_fatal_path_error
-( const char *channel, const journal::loc3_t &where, const char *msg )
+(const char *msg )
 {
-  throw_( channel, where, msg);
-}
-
-void
-mcni::throw_fatal_path_error
-( const char *channel, const journal::loc2_t &where, const char *msg )
-{
-  throw_( channel, where, msg);
+  throw_(msg);
 }
 
 

--- a/packages/mcni/lib/mcni/process_neutron_events.cc
+++ b/packages/mcni/lib/mcni/process_neutron_events.cc
@@ -12,8 +12,6 @@
 //
 
 
-#include "journal/error.h"
-#include "journal/debug.h"
 
 #include "mcni/neutron.h"
 
@@ -32,9 +30,6 @@ namespace {
   void _process_T
   (NC *nc, mcni::Neutron::Events &evts)
   {
-#ifdef DEEPDEBUG
-    journal::debug_t debug("scatter");
-#endif
     using namespace mcni;
 
     static Neutron::Event swap_temp;
@@ -73,9 +68,6 @@ namespace {
   void _processM_T
   (NC *nc, mcni::Neutron::Events &evts)
   {
-#ifdef DEEPDEBUG
-    journal::debug_t debug("scatter");
-#endif
     using namespace mcni;
     using namespace std;
 

--- a/packages/mcni/lib/test/exception.h
+++ b/packages/mcni/lib/test/exception.h
@@ -15,7 +15,6 @@
 #define MCNI_TEST_EXCEPTION_H
 
 
-#include "journal/error.h"
 #include <string>
 
 
@@ -48,45 +47,29 @@ namespace mcni {
   
   
 
-  /// throw an exception and print out error message through journal
+  /// throw an exception
   /*!
-    @param channel:  journal channel name
-    @param where: usually journal::at(__HERE__)
     @param e: exception instance
   */
-  template <typename loc_t>
-  void throw_( const char *channel, const loc_t &where, const mcni::Exception &e)
+  inline void throw_(const mcni::Exception &e)
   {
-    journal::error_t err(channel);
-    err << where
-	<< e.what()
-	<< journal::endl;
     throw e;
   }
   
   
 
-  /// throw an exception and print out error message through journal
+  /// throw an exception
   /*!
     the type of exception to throw is given as template parameter
-    @param channel: journal channel name
-    @param where: usually journal::at(__HERE__)
   */
   template <typename exception_t, typename loc_t>
-  void throw_( const char *channel, const loc_t &where)
+  void throw_()
   {
-    journal::error_t err(channel);
     exception_t e;
-    err << where
-	<< e.what()
-	<< journal::endl;
     throw e;
   }
   
   
-  //   void throw_( const char *channel, const journal::loc3_t & whre, const Exception & e );
-  //   void throw_( const char *channel, const journal::loc2_t & whre, const Exception & e );
-
 } //mcni
 
 #endif //MCNI_TEST_EXCEPTION_H


### PR DESCRIPTION
This removes all references to journal in all the C++ files. Please take a careful look at the exception files as they have changed slightly to handle the removal of journal.

EWM: [11167](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11167)